### PR TITLE
事务日志zookeeper实现

### DIFF
--- a/hmily-repository/hmily-repository-zookeeper/pom.xml
+++ b/hmily-repository/hmily-repository-zookeeper/pom.xml
@@ -40,6 +40,11 @@
             <artifactId>hmily-common</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.dromara</groupId>
+            <artifactId>hmily-serializer-all</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.zookeeper</groupId>
@@ -51,7 +56,6 @@
                 </exclusion>
             </exclusions>
         </dependency>
-
     </dependencies>
 
 </project>

--- a/hmily-repository/hmily-repository-zookeeper/src/main/java/org/dromara/hmily/repository/zookeeper/ZookeeperRepository.java
+++ b/hmily-repository/hmily-repository-zookeeper/src/main/java/org/dromara/hmily/repository/zookeeper/ZookeeperRepository.java
@@ -17,16 +17,19 @@
 
 package org.dromara.hmily.repository.zookeeper;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
-import org.apache.zookeeper.CreateMode;
-import org.apache.zookeeper.Watcher;
-import org.apache.zookeeper.ZooDefs;
-import org.apache.zookeeper.ZooKeeper;
+
+import org.apache.zookeeper.*;
 import org.apache.zookeeper.data.Stat;
+import org.dromara.hmily.common.exception.HmilyException;
 import org.dromara.hmily.common.exception.HmilyRuntimeException;
+import org.dromara.hmily.common.utils.CollectionUtils;
 import org.dromara.hmily.common.utils.LogUtil;
+import org.dromara.hmily.common.utils.StringUtils;
 import org.dromara.hmily.config.HmilyConfig;
 import org.dromara.hmily.config.HmilyZookeeperConfig;
 import org.dromara.hmily.repository.spi.HmilyRepository;
@@ -35,6 +38,7 @@ import org.dromara.hmily.repository.spi.entity.HmilyParticipantUndo;
 import org.dromara.hmily.repository.spi.entity.HmilyTransaction;
 import org.dromara.hmily.repository.spi.exception.HmilyRepositoryException;
 import org.dromara.hmily.serializer.spi.HmilySerializer;
+import org.dromara.hmily.spi.HmilySPI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,22 +47,32 @@ import org.slf4j.LoggerFactory;
  *
  * @author xiaoyu
  */
+@HmilySPI("zookeeper")
 public class ZookeeperRepository implements HmilyRepository {
-    
+
     private static final Logger LOGGER = LoggerFactory.getLogger(ZookeeperRepository.class);
-    
+
     private static volatile ZooKeeper zooKeeper;
-    
+
     private static final CountDownLatch LATCH = new CountDownLatch(1);
-    
+
     private HmilySerializer hmilySerializer;
-    
+
     private String rootPathPrefix = "/hmily";
-    
-    
+
+    private String appName = "default";
+
+    private static final String HMILY_TRANSACTION_GLOBAL = "hmily_transaction_global";
+
+    private static final String HMILY_TRANSACTION_PRTICIPANT = "hmily_transaction_participant";
+
+    private static final String HMILY_PARTICIPANT_UNDO = "hmily_participant_undo";
+
+
     @Override
     public void init(final HmilyConfig hmilyConfig) {
-        rootPathPrefix = hmilyConfig.getAppName();
+//        rootPathPrefix = hmilyConfig.getAppName();
+        appName = hmilyConfig.getAppName();
         try {
             connect(hmilyConfig.getHmilyZookeeperConfig());
         } catch (Exception e) {
@@ -66,117 +80,379 @@ public class ZookeeperRepository implements HmilyRepository {
             throw new HmilyRuntimeException(e.getMessage());
         }
     }
-    
+
     @Override
     public void setSerializer(final HmilySerializer hmilySerializer) {
         this.hmilySerializer = hmilySerializer;
     }
-    
+
     @Override
     public int createHmilyTransaction(HmilyTransaction hmilyTransaction) throws HmilyRepositoryException {
-        return 0;
+        String path = rootPathPrefix + "/" + appName + "/" + HMILY_TRANSACTION_GLOBAL;
+        try {
+            create(path);
+            Stat stat = zooKeeper.exists(path + "/" + hmilyTransaction.getTransId(), false);
+            if (stat == null) {
+                hmilyTransaction.setRetry(0);
+                hmilyTransaction.setVersion(0);
+                hmilyTransaction.setCreateTime(new Date());
+                hmilyTransaction.setUpdateTime(new Date());
+                zooKeeper.create(path + "/" + hmilyTransaction.getTransId(),
+                        hmilySerializer.serialize(hmilyTransaction), ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+            } else {
+                hmilyTransaction.setVersion(hmilyTransaction.getVersion() + 1);
+                hmilyTransaction.setUpdateTime(new Date());
+                zooKeeper.setData(path + "/" + hmilyTransaction.getTransId(),
+                        hmilySerializer.serialize(hmilyTransaction), stat.getVersion());
+            }
+            return HmilyRepository.ROWS;
+        } catch (KeeperException e) {
+            throw new HmilyException(e);
+        } catch (InterruptedException e) {
+            throw new HmilyException(e);
+        }
     }
-    
+
     @Override
     public int updateRetryByLock(HmilyTransaction hmilyTransaction) {
-        return 0;
+        final int currentVersion = hmilyTransaction.getVersion();
+        String path = rootPathPrefix + "/" + appName + "/" + HMILY_TRANSACTION_GLOBAL + "/" + hmilyTransaction.getTransId();
+        try {
+            Stat stat = zooKeeper.exists(path, false);
+            if (stat == null) {
+                LOGGER.warn("path {} is not exists.", path);
+                return HmilyRepository.FAIL_ROWS;
+            }
+            if (currentVersion != stat.getVersion()) {
+                LOGGER.warn("current transaction data version different from zookeeper server. " +
+                        "current version: {}, server data version:  {}", currentVersion, stat.getVersion());
+            }
+            hmilyTransaction.setVersion(currentVersion + 1);
+            hmilyTransaction.setRetry(hmilyTransaction.getRetry() + 1);
+            hmilyTransaction.setUpdateTime(new Date());
+            zooKeeper.setData(path, hmilySerializer.serialize(hmilyTransaction), stat.getVersion());
+            return HmilyRepository.ROWS;
+        } catch (KeeperException e) {
+            LOGGER.error("updateRetryByLock occur a exception", e);
+        } catch (InterruptedException e) {
+            LOGGER.error("updateRetryByLock occur a exception", e);
+        }
+        return HmilyRepository.FAIL_ROWS;
     }
-    
+
     @Override
     public HmilyTransaction findByTransId(Long transId) {
+        String path = rootPathPrefix + "/" + appName + "/" + HMILY_TRANSACTION_GLOBAL + "/" + transId;
+        try {
+            byte[] data = zooKeeper.getData(path, false, null);
+            if (data == null) {
+                return null;
+            }
+            return hmilySerializer.deSerialize(data, HmilyTransaction.class);
+        } catch (KeeperException e) {
+            LOGGER.error("findByTransId occur a exception", e);
+        } catch (InterruptedException e) {
+            LOGGER.error("findByTransId occur a exception", e);
+        }
+
         return null;
     }
-    
+
     @Override
     public List<HmilyTransaction> listLimitByDelay(Date date, int limit) {
-        return null;
+        String path = rootPathPrefix + "/" + appName + "/" + HMILY_TRANSACTION_GLOBAL;
+        List<HmilyTransaction> result = listByFilter(path, HmilyTransaction.class, (hmilyTransaction, params) -> {
+            Date dateParam = (Date) params[0];
+            int limitParam = (int) params[1];
+            boolean filterResult = dateParam.before(hmilyTransaction.getUpdateTime())
+                    && appName.equals(hmilyTransaction.getAppName())
+                    && limitParam-- > 0;
+            // write back to params
+            params[1] = limitParam;
+            return filterResult;
+        }, date, limit);
+        return result;
     }
-    
+
     @Override
     public int updateHmilyTransactionStatus(Long transId, Integer status) throws HmilyRepositoryException {
-        return 0;
+        String path = rootPathPrefix + "/" + appName + "/" + HMILY_TRANSACTION_GLOBAL + "/" + transId;
+        Stat stat = new Stat();
+        try {
+            byte[] data = zooKeeper.getData(path, false, stat);
+            if (data == null) {
+                return HmilyRepository.FAIL_ROWS;
+            }
+
+            HmilyTransaction hmilyTransaction = hmilySerializer.deSerialize(data, HmilyTransaction.class);
+            hmilyTransaction.setStatus(status);
+            hmilyTransaction.setVersion(hmilyTransaction.getVersion() + 1);
+            hmilyTransaction.setUpdateTime(new Date());
+            zooKeeper.setData(path, hmilySerializer.serialize(hmilyTransaction), stat.getVersion());
+            return HmilyRepository.ROWS;
+        } catch (KeeperException e) {
+            LOGGER.error("updateHmilyTransactionStatus occur a exception", e);
+        } catch (InterruptedException e) {
+            LOGGER.error("updateHmilyTransactionStatus occur a exception", e);
+        }
+
+        return HmilyRepository.FAIL_ROWS;
     }
-    
+
     @Override
     public int removeHmilyTransaction(Long transId) {
-        return 0;
+        String path = rootPathPrefix + "/" + appName + "/" + HMILY_TRANSACTION_GLOBAL + "/" + transId;
+        try {
+            zooKeeper.delete(path, -1);
+            return HmilyRepository.ROWS;
+        } catch (InterruptedException e) {
+            LOGGER.error("removeHmilyTransaction occur a exception", e);
+        } catch (KeeperException e) {
+            LOGGER.error("removeHmilyTransaction occur a exception", e);
+        }
+
+        return HmilyRepository.FAIL_ROWS;
     }
-    
+
     @Override
     public int removeHmilyTransactionByData(Date date) {
-        return 0;
+        String path = rootPathPrefix + "/" + appName + "/" + HMILY_TRANSACTION_GLOBAL;
+        return removeByDate(path, HmilyTransaction.class, ((hmilyTransaction, params) -> {
+            Date dateParam = (Date) params[0];
+            return dateParam.before(hmilyTransaction.getUpdateTime()) && hmilyTransaction.getStatus() == 4;
+        }), date);
     }
-    
+
     @Override
     public int createHmilyParticipant(HmilyParticipant hmilyParticipant) throws HmilyRepositoryException {
-        return 0;
+        try {
+            String path = rootPathPrefix + "/" + appName + "/" + HMILY_TRANSACTION_PRTICIPANT;
+            create(path);
+            Stat stat = zooKeeper.exists(path + "/" + hmilyParticipant.getTransId(), false);
+            if (stat == null) {
+                hmilyParticipant.setRetry(0);
+                hmilyParticipant.setVersion(0);
+                hmilyParticipant.setCreateTime(new Date());
+                hmilyParticipant.setUpdateTime(new Date());
+                zooKeeper.create(path + "/" + hmilyParticipant.getParticipantId(),
+                        hmilySerializer.serialize(hmilyParticipant), ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+            } else {
+                hmilyParticipant.setVersion(hmilyParticipant.getVersion() + 1);
+                hmilyParticipant.setUpdateTime(new Date());
+                zooKeeper.setData(path + "/" + hmilyParticipant.getParticipantId(),
+                        hmilySerializer.serialize(hmilyParticipant), stat.getVersion());
+            }
+            return HmilyRepository.ROWS;
+        } catch (KeeperException e) {
+            throw new HmilyException(e);
+        } catch (InterruptedException e) {
+            throw new HmilyException(e);
+        }
     }
-    
+
     @Override
     public List<HmilyParticipant> findHmilyParticipant(Long participantId) {
-        return null;
+        String path = rootPathPrefix + "/" + appName + "/" + HMILY_TRANSACTION_PRTICIPANT;
+        List<HmilyParticipant> result = listByFilter(path, HmilyParticipant.class, (hmilyParticipant, params) -> {
+            Long participantIdParam = (Long) params[0];
+            return participantIdParam.compareTo(hmilyParticipant.getParticipantId()) == 0
+                    || participantIdParam.compareTo(hmilyParticipant.getParticipantRefId()) == 0;
+        }, participantId);
+        return result;
     }
-    
+
     @Override
     public List<HmilyParticipant> listHmilyParticipant(Date date, String transType, int limit) {
-        return null;
+        String path = rootPathPrefix + "/" + appName + "/" + HMILY_TRANSACTION_PRTICIPANT;
+        List<HmilyParticipant> result = listByFilter(path, HmilyParticipant.class,
+                (hmilyParticipant, params) -> {
+                    Date dateParam = (Date) params[0];
+                    String transTypeParam = (String) params[1];
+                    int limitParam = (int) params[2];
+                    boolean filterResult = dateParam.before(hmilyParticipant.getUpdateTime()) && appName.equals(hmilyParticipant.getAppName())
+                            && transTypeParam.equals(hmilyParticipant.getTransType())
+                            && (hmilyParticipant.getStatus().compareTo(4) != 0 && hmilyParticipant.getStatus().compareTo(8) != 0)
+                            && limitParam-- > 0;
+                    params[2] = limitParam;
+                    return filterResult;
+                },
+                date, transType, limit);
+        return result;
     }
-    
+
     @Override
     public List<HmilyParticipant> listHmilyParticipantByTransId(Long transId) {
-        return null;
+        String path = rootPathPrefix + "/" + appName + "/" + HMILY_TRANSACTION_PRTICIPANT;
+        List<HmilyParticipant> result = listByFilter(path, HmilyParticipant.class,
+                (hmilyParticipant, params) -> transId.compareTo(hmilyParticipant.getTransId()) == 0,
+                transId);
+        return result;
     }
-    
+
     @Override
     public boolean existHmilyParticipantByTransId(Long transId) {
-        return false;
+        String path = rootPathPrefix + "/" + appName + "/" + HMILY_TRANSACTION_PRTICIPANT;
+        return existByFilter(path, HmilyParticipant.class, (hmilyParticipant, params) -> {
+            Long transIdParam = (Long) params[0];
+            return transIdParam.compareTo(hmilyParticipant.getTransId()) == 0;
+        }, transId);
     }
-    
+
     @Override
     public int updateHmilyParticipantStatus(Long participantId, Integer status) throws HmilyRepositoryException {
-        return 0;
+        String path = rootPathPrefix + "/" + appName + "/" + HMILY_TRANSACTION_PRTICIPANT + "/" + participantId;
+        try {
+            Stat stat = new Stat();
+            byte[] data = zooKeeper.getData(path, false, stat);
+            if (data == null) {
+                return HmilyRepository.FAIL_ROWS;
+            }
+
+            HmilyParticipant hmilyParticipant = hmilySerializer.deSerialize(data, HmilyParticipant.class);
+            hmilyParticipant.setStatus(status);
+            hmilyParticipant.setVersion(hmilyParticipant.getVersion() + 1);
+            hmilyParticipant.setUpdateTime(new Date());
+            zooKeeper.setData(path, hmilySerializer.serialize(hmilyParticipant), stat.getVersion());
+            return HmilyRepository.ROWS;
+        } catch (KeeperException e) {
+            LOGGER.error("updateHmilyParticipantStatus occur a exception", e);
+        } catch (InterruptedException e) {
+            LOGGER.error("updateHmilyParticipantStatus occur a exception", e);
+        }
+
+        return HmilyRepository.FAIL_ROWS;
     }
-    
+
     @Override
     public int removeHmilyParticipant(Long participantId) {
-        return 0;
+        String path = rootPathPrefix + "/" + appName + "/" + HMILY_TRANSACTION_PRTICIPANT + "/" + participantId;
+        try {
+            zooKeeper.delete(path, -1);
+            return HmilyRepository.ROWS;
+        } catch (InterruptedException e) {
+            LOGGER.error("removeHmilyParticipant occur a exception", e);
+        } catch (KeeperException e) {
+            LOGGER.error("removeHmilyParticipant occur a exception", e);
+        }
+        return HmilyRepository.FAIL_ROWS;
     }
-    
+
     @Override
     public int removeHmilyParticipantByData(Date date) {
-        return 0;
+        String path = rootPathPrefix + "/" + appName + "/" + HMILY_TRANSACTION_PRTICIPANT;
+        return removeByDate(path, HmilyParticipant.class, (hmilyParticipant, params) -> {
+            Date dateParam = (Date) params[0];
+            return dateParam.before(hmilyParticipant.getUpdateTime()) && hmilyParticipant.getStatus().compareTo(4) == 0;
+        }, date);
     }
-    
+
     @Override
     public boolean lockHmilyParticipant(HmilyParticipant hmilyParticipant) {
+        final int currentVersion = hmilyParticipant.getVersion();
+        String path = rootPathPrefix + "/" + appName + "/" + HMILY_TRANSACTION_PRTICIPANT + "/" + hmilyParticipant.getParticipantId();
+        try {
+            Stat stat = zooKeeper.exists(path, false);
+            if (stat == null) {
+                LOGGER.warn("path {} is not exists.", path);
+                return false;
+            }
+            if (currentVersion != stat.getVersion()) {
+                LOGGER.warn("current transaction participant data version different from zookeeper server. " +
+                        "current version: {}, server data version:  {}", currentVersion, stat.getVersion());
+            }
+            hmilyParticipant.setVersion(currentVersion + 1);
+            hmilyParticipant.setRetry(hmilyParticipant.getRetry() + 1);
+            hmilyParticipant.setUpdateTime(new Date());
+            zooKeeper.setData(path, hmilySerializer.serialize(hmilyParticipant), stat.getVersion());
+            return true;
+        } catch (KeeperException e) {
+            LOGGER.error("updateRetryByLock occur a exception", e);
+        } catch (InterruptedException e) {
+            LOGGER.error("updateRetryByLock occur a exception", e);
+        }
         return false;
     }
-    
+
     @Override
     public int createHmilyParticipantUndo(HmilyParticipantUndo hmilyParticipantUndo) {
-        return 0;
+        String path = rootPathPrefix + "/" + appName + "/" + HMILY_PARTICIPANT_UNDO;
+        try {
+            create(path);
+            Stat stat = zooKeeper.exists(path + "/" + hmilyParticipantUndo.getUndoId(), false);
+            if (stat == null) {
+                hmilyParticipantUndo.setCreateTime(new Date());
+                hmilyParticipantUndo.setUpdateTime(new Date());
+                zooKeeper.create(path + "/" + hmilyParticipantUndo.getUndoId(),
+                        hmilySerializer.serialize(hmilyParticipantUndo), ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+            } else {
+                hmilyParticipantUndo.setUpdateTime(new Date());
+                zooKeeper.setData(path + "/" + hmilyParticipantUndo.getUndoId(),
+                        hmilySerializer.serialize(hmilyParticipantUndo), stat.getVersion());
+            }
+            return HmilyRepository.ROWS;
+        } catch (KeeperException e) {
+            throw new HmilyException(e);
+        } catch (InterruptedException e) {
+            throw new HmilyException(e);
+        }
     }
-    
+
     @Override
     public List<HmilyParticipantUndo> findHmilyParticipantUndoByParticipantId(Long participantId) {
-        return null;
+        String path = rootPathPrefix + "/" + appName + "/" + HMILY_PARTICIPANT_UNDO;
+        return listByFilter(path, HmilyParticipantUndo.class, (undo, params) -> {
+            Long participantIdParam = (Long) params[0];
+            return participantIdParam.compareTo(undo.getParticipantId()) == 0;
+        }, participantId);
     }
-    
+
     @Override
     public int removeHmilyParticipantUndo(Long undoId) {
-        return 0;
+        String path = rootPathPrefix + "/" + appName + "/" + HMILY_PARTICIPANT_UNDO + "/" + undoId;
+        try {
+            zooKeeper.delete(path, -1);
+            return HmilyRepository.ROWS;
+        } catch (InterruptedException e) {
+            LOGGER.error("removeHmilyParticipantUndo occur a exception", e);
+        } catch (KeeperException e) {
+            LOGGER.error("removeHmilyParticipantUndo occur a exception", e);
+        }
+        return HmilyRepository.FAIL_ROWS;
     }
-    
+
     @Override
     public int removeHmilyParticipantUndoByData(Date date) {
-        return 0;
+        String path = rootPathPrefix + "/" + appName + "/" + HMILY_PARTICIPANT_UNDO;
+        return removeByDate(path, HmilyParticipantUndo.class, (undo, params) -> {
+            Date dateParam = (Date) params[0];
+            return dateParam.before(undo.getUpdateTime()) && undo.getStatus().compareTo(4) == 0;
+        }, date);
     }
-    
+
     @Override
     public int updateHmilyParticipantUndoStatus(Long undoId, Integer status) {
-        return 0;
+        String path = rootPathPrefix + "/" + appName + "/" + HMILY_PARTICIPANT_UNDO + "/" + undoId;
+        try {
+            Stat stat = new Stat();
+            byte[] data = zooKeeper.getData(path, false, stat);
+            if (data == null) {
+                return HmilyRepository.FAIL_ROWS;
+            }
+
+            HmilyParticipantUndo hmilyParticipantUndo = hmilySerializer.deSerialize(data, HmilyParticipantUndo.class);
+            hmilyParticipantUndo.setStatus(status);
+            hmilyParticipantUndo.setUpdateTime(new Date());
+            zooKeeper.setData(path, hmilySerializer.serialize(hmilyParticipantUndo), stat.getVersion());
+            return HmilyRepository.ROWS;
+        } catch (KeeperException e) {
+            LOGGER.error("updateHmilyParticipantStatus occur a exception", e);
+        } catch (InterruptedException e) {
+            LOGGER.error("updateHmilyParticipantStatus occur a exception", e);
+        }
+
+        return HmilyRepository.FAIL_ROWS;
     }
-    
+
     private void connect(final HmilyZookeeperConfig config) {
         try {
             zooKeeper = new ZooKeeper(config.getHost(), config.getSessionTimeOut(), watchedEvent -> {
@@ -192,5 +468,126 @@ public class ZookeeperRepository implements HmilyRepository {
         } catch (Exception e) {
             throw new HmilyRuntimeException(e);
         }
+    }
+
+    private void create(String path) throws KeeperException, InterruptedException {
+        PathTokenizer pathTokenizer = new PathTokenizer(path);
+        while (pathTokenizer.hasNext()) {
+            String nextPath = pathTokenizer.nextPath();
+            if (StringUtils.isNoneBlank(path)) {
+                Stat stat = zooKeeper.exists(nextPath, false);
+                if (stat == null) {
+                    zooKeeper.create(nextPath, nextPath.getBytes(), ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+                }
+            }
+        }
+    }
+
+    private <T> List<T> listByFilter(String path, Class<T> deserializeClass, Filter<T> filter, Object... params) {
+        try {
+            List<String> children = zooKeeper.getChildren(path, false);
+            if (CollectionUtils.isEmpty(children)) {
+                return Collections.emptyList();
+            }
+
+            List<T> result = new ArrayList<>();
+            for (String child : children) {
+                byte[] data = zooKeeper.getData(path + "/" + child, false, null);
+                if (data == null) {
+                    continue;
+                }
+                T t = hmilySerializer.deSerialize(data, deserializeClass);
+                if (filter.filter(t, params)) {
+                    result.add(t);
+                }
+            }
+            return result;
+        } catch (KeeperException e) {
+            LOGGER.error("listByFilter occur a exception", e);
+        } catch (InterruptedException e) {
+            LOGGER.error("listByFilter occur a exception", e);
+        }
+        return Collections.emptyList();
+    }
+
+    private <T> boolean existByFilter(String path, Class<T> deserializeClass, Filter<T> filter, Object... params) {
+        try {
+            List<String> children = zooKeeper.getChildren(path, false);
+            if (CollectionUtils.isEmpty(children)) {
+                return false;
+            }
+
+            for (String child : children) {
+                byte[] data = zooKeeper.getData(path + "/" + child, false, null);
+                if (data == null) {
+                    continue;
+                }
+                T t = hmilySerializer.deSerialize(data, deserializeClass);
+                if (filter.filter(t, params)) {
+                    return true;
+                }
+            }
+        } catch (KeeperException e) {
+            LOGGER.error("existByFilter occur a exception", e);
+        } catch (InterruptedException e) {
+            LOGGER.error("existByFilter occur a exception", e);
+        }
+        return false;
+    }
+
+    private <T> int removeByDate(String path, Class<T> deserializeClass, Filter<T> filter, Object... params) {
+        try {
+            List<String> children = zooKeeper.getChildren(path, false);
+            if (CollectionUtils.isEmpty(children)) {
+                return HmilyRepository.FAIL_ROWS;
+            }
+
+            int count = 0;
+            for (String child : children) {
+                Stat stat = new Stat();
+                byte[] data = zooKeeper.getData(path + "/" + child, false, stat);
+                if (data == null) {
+                    continue;
+                }
+                T t = hmilySerializer.deSerialize(data, deserializeClass);
+                if (filter.filter(t, params)) {
+                    zooKeeper.delete(path + "/" + child, stat.getVersion());
+                    count++;
+                }
+            }
+            return count;
+        } catch (KeeperException e) {
+            LOGGER.error("removeByDate occur a exception", e);
+        } catch (InterruptedException e) {
+            LOGGER.error("removeByDate occur a exception", e);
+        }
+        return HmilyRepository.FAIL_ROWS;
+    }
+
+    class PathTokenizer {
+        String path = "";
+        String[] nodes;
+        int index = 0;
+
+        PathTokenizer(String path) {
+            nodes = path.split("/");
+            if (path.startsWith("/")) {
+                index = 1;
+            }
+        }
+
+        public String nextPath() {
+            path = path + "/" + nodes[index];
+            index++;
+            return path;
+        }
+
+        public boolean hasNext() {
+            return index < nodes.length;
+        }
+    }
+
+    interface Filter<T> {
+        boolean filter(T t, Object... params);
     }
 }

--- a/hmily-repository/hmily-repository-zookeeper/src/main/java/org/dromara/hmily/repository/zookeeper/ZookeeperRepository.java
+++ b/hmily-repository/hmily-repository-zookeeper/src/main/java/org/dromara/hmily/repository/zookeeper/ZookeeperRepository.java
@@ -499,7 +499,7 @@ public class ZookeeperRepository implements HmilyRepository {
         }
     }
 
-    private boolean checkAndInitPath(final String path, boolean needCreate) throws KeeperException, InterruptedException {
+    private boolean checkAndInitPath(final String path, final boolean needCreate) throws KeeperException, InterruptedException {
         Stat stat = zooKeeper.exists(path, false);
         if (stat != null) {
             return true;

--- a/hmily-repository/hmily-repository-zookeeper/src/main/java/org/dromara/hmily/repository/zookeeper/ZookeeperRepository.java
+++ b/hmily-repository/hmily-repository-zookeeper/src/main/java/org/dromara/hmily/repository/zookeeper/ZookeeperRepository.java
@@ -318,7 +318,9 @@ public class ZookeeperRepository implements HmilyRepository {
     public int updateHmilyParticipantStatus(final Long participantId, final Integer status) throws HmilyRepositoryException {
         String path = rootPathPrefix + "/" + appName + "/" + HMILY_TRANSACTION_PRTICIPANT + "/" + participantId;
         try {
-            checkAndInitPath(path, true);
+            if (!checkAndInitPath(path, false)) {
+                return FAIL_ROWS;
+            }
             Stat stat = new Stat();
             byte[] data = zooKeeper.getData(path, false, stat);
             if (data == null) {

--- a/hmily-repository/hmily-repository-zookeeper/src/test/java/org/dromara/hmily/repository/zookeeper/ZookeeperRepositoryTest.java
+++ b/hmily-repository/hmily-repository-zookeeper/src/test/java/org/dromara/hmily/repository/zookeeper/ZookeeperRepositoryTest.java
@@ -64,9 +64,9 @@ public class ZookeeperRepositoryTest {
             zooKeeper.delete("/hmily/" + appName + "/" + HMILY_TRANSACTION_PRTICIPANT, stat.getVersion());
         }
 
-        stat = zooKeeper.exists("/hmily/" + appName + "/" + HMILY_TRANSACTION_PRTICIPANT, false);
+        stat = zooKeeper.exists("/hmily/" + appName + "/" + HMILY_PARTICIPANT_UNDO, false);
         if (stat != null) {
-            zooKeeper.delete("/hmily/" + appName + "/" + HMILY_TRANSACTION_PRTICIPANT, stat.getVersion());
+            zooKeeper.delete("/hmily/" + appName + "/" + HMILY_PARTICIPANT_UNDO, stat.getVersion());
         }
     }
 

--- a/hmily-repository/hmily-repository-zookeeper/src/test/java/org/dromara/hmily/repository/zookeeper/ZookeeperRepositoryTest.java
+++ b/hmily-repository/hmily-repository-zookeeper/src/test/java/org/dromara/hmily/repository/zookeeper/ZookeeperRepositoryTest.java
@@ -17,12 +17,14 @@ import java.util.Calendar;
 import java.util.List;
 import java.util.Random;
 
-import static org.junit.Assert.*;
-
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 /**
  * Author:   lilang
  * Date:     2020-08-16 10:58
- * Description: 依赖于zookeeper的特性，所以暂不进行mock
+ * Description: zookeeper repository test crud
  **/
 public class ZookeeperRepositoryTest {
 

--- a/hmily-repository/hmily-repository-zookeeper/src/test/java/org/dromara/hmily/repository/zookeeper/ZookeeperRepositoryTest.java
+++ b/hmily-repository/hmily-repository-zookeeper/src/test/java/org/dromara/hmily/repository/zookeeper/ZookeeperRepositoryTest.java
@@ -1,0 +1,250 @@
+package org.dromara.hmily.repository.zookeeper;
+
+import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.data.Stat;
+import org.dromara.hmily.annotation.TransTypeEnum;
+import org.dromara.hmily.config.HmilyConfig;
+import org.dromara.hmily.config.HmilyZookeeperConfig;
+import org.dromara.hmily.repository.spi.entity.HmilyParticipant;
+import org.dromara.hmily.repository.spi.entity.HmilyParticipantUndo;
+import org.dromara.hmily.repository.spi.entity.HmilyTransaction;
+import org.dromara.hmily.serializer.kryo.KryoSerializer;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.Calendar;
+import java.util.List;
+import java.util.Random;
+
+import static org.junit.Assert.*;
+
+/**
+ * Author:   lilang
+ * Date:     2020-08-16 10:58
+ * Description: 依赖于zookeeper的特性，所以暂不进行mock
+ **/
+public class ZookeeperRepositoryTest {
+
+    private ZookeeperRepository zookeeperRepository = new ZookeeperRepository();
+
+    private HmilyConfig hmilyConfig = new HmilyConfig();
+    private HmilyZookeeperConfig hmilyZookeeperConfig = new HmilyZookeeperConfig();
+
+    private String appName = "test_hmily_zookeeper";
+    private Random random = new Random(System.currentTimeMillis());
+
+    private static final String HMILY_TRANSACTION_GLOBAL = "hmily_transaction_global";
+
+    private static final String HMILY_TRANSACTION_PRTICIPANT = "hmily_transaction_participant";
+
+    private static final String HMILY_PARTICIPANT_UNDO = "hmily_participant_undo";
+
+    @Before
+    public void setUp() throws Exception {
+        hmilyConfig.setAppName(appName);
+        hmilyConfig.setHmilyZookeeperConfig(hmilyZookeeperConfig);
+        hmilyZookeeperConfig.setHost("127.0.0.1:2181");
+        hmilyZookeeperConfig.setSessionTimeOut(300000);
+
+        zookeeperRepository.init(hmilyConfig);
+        zookeeperRepository.setSerializer(new KryoSerializer());
+
+
+        Field zooKeeperFiled = ZookeeperRepository.class.getDeclaredField("zooKeeper");
+        zooKeeperFiled.setAccessible(true);
+        ZooKeeper zooKeeper = (ZooKeeper) zooKeeperFiled.get(null);
+        Stat stat = zooKeeper.exists("/hmily/" + appName + "/" + HMILY_TRANSACTION_GLOBAL, false);
+        if (stat != null) {
+            zooKeeper.delete("/hmily/" + appName + "/" + HMILY_TRANSACTION_GLOBAL, stat.getVersion());
+        }
+
+        stat = zooKeeper.exists("/hmily/" + appName + "/" + HMILY_TRANSACTION_PRTICIPANT, false);
+        if (stat != null) {
+            zooKeeper.delete("/hmily/" + appName + "/" + HMILY_TRANSACTION_PRTICIPANT, stat.getVersion());
+        }
+
+        stat = zooKeeper.exists("/hmily/" + appName + "/" + HMILY_TRANSACTION_PRTICIPANT, false);
+        if (stat != null) {
+            zooKeeper.delete("/hmily/" + appName + "/" + HMILY_TRANSACTION_PRTICIPANT, stat.getVersion());
+        }
+    }
+
+    @Test
+    public void testCURD() {
+        Long transactionId = Long.valueOf(random.nextInt(1000));
+        testTransaction(transactionId);
+
+        Long participantId = Long.valueOf(random.nextInt(1000));
+        testParticipant(transactionId, participantId);
+
+        Long undoId = Long.valueOf(random.nextInt(1000));
+        testParticipantUndo(transactionId, participantId, undoId);
+    }
+
+    private void testTransaction(Long transactionId) {
+        HmilyTransaction hmilyTransaction = buildHmilyTransaction(transactionId);
+        int result = zookeeperRepository.createHmilyTransaction(hmilyTransaction);
+        assertNotEquals(0L, (long) result);
+
+        int updateStatusResult = zookeeperRepository.updateHmilyTransactionStatus(hmilyTransaction.getTransId(), 3);
+        assertNotEquals(0L, (long) updateStatusResult);
+
+        hmilyTransaction.setTransType(TransTypeEnum.TAC.name());
+        hmilyTransaction.setStatus(4);
+        int updateLockResult = zookeeperRepository.updateRetryByLock(hmilyTransaction);
+        assertNotEquals(0L, (long) updateLockResult);
+
+
+
+        HmilyTransaction findTransactionResult = zookeeperRepository.findByTransId(hmilyTransaction.getTransId());
+        assertNotNull(findTransactionResult);
+        assertEquals(appName, findTransactionResult.getAppName());
+        assertEquals(TransTypeEnum.TAC.name(), findTransactionResult.getTransType());
+        assertEquals(4L, findTransactionResult.getStatus());
+
+
+        hmilyTransaction = buildHmilyTransaction((long) random.nextInt(1000));
+        result = zookeeperRepository.createHmilyTransaction(hmilyTransaction);
+        assertEquals(1L, (long) result);
+
+        hmilyTransaction = buildHmilyTransaction((long) random.nextInt(1000));
+        result = zookeeperRepository.createHmilyTransaction(hmilyTransaction);
+        assertEquals(1L, (long) result);
+
+        hmilyTransaction = buildHmilyTransaction((long) random.nextInt(1000));
+        result = zookeeperRepository.createHmilyTransaction(hmilyTransaction);
+        assertEquals(1L, (long) result);
+        Calendar calendar = Calendar.getInstance();
+        calendar.add(Calendar.HOUR_OF_DAY, -1);
+        List<HmilyTransaction> listTransactionResult = zookeeperRepository.listLimitByDelay(calendar.getTime(), 2);
+        assertNotNull(listTransactionResult);
+        assertNotEquals(0L, listTransactionResult.size());
+        assertEquals(2L, (long) listTransactionResult.size());
+        int removeByIdResult = zookeeperRepository.removeHmilyTransaction(transactionId);
+        assertEquals(1L, (long) removeByIdResult);
+
+        int removeByDateResult = zookeeperRepository.removeHmilyTransactionByData(calendar.getTime());
+        assertEquals(3L, (long) removeByDateResult);
+    }
+
+    private void testParticipantUndo(Long transactionId, Long participantId, Long undoId) {
+        int result;
+        HmilyParticipantUndo hmilyParticipantUndo = buildHmilyParticipantUndo(transactionId, participantId, undoId);
+        result = zookeeperRepository.createHmilyParticipantUndo(hmilyParticipantUndo);
+        assertNotEquals(0L, (long) result);
+
+
+        int updateStatusResult = zookeeperRepository.updateHmilyParticipantUndoStatus(undoId, 3);
+        assertEquals(1L, (long) updateStatusResult);
+
+        List<HmilyParticipantUndo> findUndoResult = zookeeperRepository.findHmilyParticipantUndoByParticipantId(hmilyParticipantUndo.getParticipantId());
+        assertNotNull(findUndoResult);
+        assertNotEquals(0L, (long) findUndoResult.size());
+        assertEquals(findUndoResult.get(0).getUndoId(), hmilyParticipantUndo.getUndoId());
+        assertEquals(3L, (long) findUndoResult.get(0).getStatus());
+
+
+        int removeByIdResult = zookeeperRepository.removeHmilyParticipantUndo(undoId);
+        assertEquals(1L, (long) removeByIdResult);
+
+        hmilyParticipantUndo = buildHmilyParticipantUndo(transactionId, participantId, (long) random.nextInt(1000));
+        result = zookeeperRepository.createHmilyParticipantUndo(hmilyParticipantUndo);
+        assertNotEquals(0L, (long) result);
+        hmilyParticipantUndo = buildHmilyParticipantUndo(transactionId, participantId, (long) random.nextInt(1000));
+        result = zookeeperRepository.createHmilyParticipantUndo(hmilyParticipantUndo);
+        assertNotEquals(0L, (long) result);
+        hmilyParticipantUndo = buildHmilyParticipantUndo(transactionId, participantId, (long) random.nextInt(1000));
+        result = zookeeperRepository.createHmilyParticipantUndo(hmilyParticipantUndo);
+        assertNotEquals(0L, (long) result);
+
+        Calendar calendar = Calendar.getInstance();
+        calendar.add(Calendar.HOUR_OF_DAY, -1);
+        int removeByDateResult = zookeeperRepository.removeHmilyParticipantUndoByData(calendar.getTime());
+        assertEquals(3L, (long) removeByDateResult);
+    }
+
+    private void testParticipant(Long transactionId, Long participantId) {
+        HmilyParticipant hmilyParticipant = buildHmilyParticipant(transactionId, participantId);
+        int result = zookeeperRepository.createHmilyParticipant(hmilyParticipant);
+        assertNotEquals(0L, (long) result);
+
+
+        int updateStatusResult = zookeeperRepository.updateHmilyParticipantStatus(participantId, 5);
+        assertEquals(1L, updateStatusResult);
+        hmilyParticipant.setStatus(4);
+        boolean lockUpdateResult = zookeeperRepository.lockHmilyParticipant(hmilyParticipant);
+        assertTrue(lockUpdateResult);
+
+        List<HmilyParticipant> findParticipantResult = zookeeperRepository.findHmilyParticipant(hmilyParticipant.getParticipantId());
+        assertNotNull(findParticipantResult);
+        assertNotEquals(0L, (long) findParticipantResult.size());
+        assertTrue(findParticipantResult.get(0).getParticipantId().equals(hmilyParticipant.getParticipantId()) ||
+                findParticipantResult.get(0).getParticipantRefId().equals(hmilyParticipant.getParticipantId()));
+        assertEquals(4L, (long) findParticipantResult.stream()
+                .filter(x -> x.getParticipantId()
+                        .equals(participantId)).findFirst().get().getStatus());
+
+        Calendar calendar = Calendar.getInstance();
+        calendar.add(Calendar.HOUR_OF_DAY, -1);
+        long id1 = random.nextInt(1000);
+        hmilyParticipant = buildHmilyParticipant(transactionId, id1);
+        result = zookeeperRepository.createHmilyParticipant(hmilyParticipant);
+        assertEquals(1L, result);
+        long id2 = random.nextInt(1000);
+        hmilyParticipant = buildHmilyParticipant(transactionId, id2);
+        result = zookeeperRepository.createHmilyParticipant(hmilyParticipant);
+        assertEquals(1L, result);
+        long id3 = random.nextInt(1000);
+        hmilyParticipant = buildHmilyParticipant(transactionId, id3);
+        result = zookeeperRepository.createHmilyParticipant(hmilyParticipant);
+        assertEquals(1L, result);
+        List<HmilyParticipant> listResult = zookeeperRepository.listHmilyParticipant(calendar.getTime(), TransTypeEnum.TCC.name(), 2);
+        assertEquals(2L, listResult.size());
+
+        List<HmilyParticipant> listByTransactionIdResult = zookeeperRepository.listHmilyParticipantByTransId(transactionId);
+        assertEquals(4L, listByTransactionIdResult.size());
+
+        boolean existsRsult = zookeeperRepository.existHmilyParticipantByTransId(transactionId);
+        assertTrue(existsRsult);
+
+        int removeByIdResult = zookeeperRepository.removeHmilyParticipant(participantId);
+        assertEquals(1L, (long) removeByIdResult);
+
+        zookeeperRepository.updateHmilyParticipantStatus(id1, 4);
+        zookeeperRepository.updateHmilyParticipantStatus(id2, 4);
+        zookeeperRepository.updateHmilyParticipantStatus(id3, 4);
+        int removeByDateResult = zookeeperRepository.removeHmilyParticipantByData(calendar.getTime());
+        assertEquals(3L, (long) removeByDateResult);
+    }
+
+    private HmilyParticipantUndo buildHmilyParticipantUndo(Long transactionId, Long particaipantId, Long undoId) {
+        HmilyParticipantUndo hmilyParticipantUndo = new HmilyParticipantUndo();
+        hmilyParticipantUndo.setStatus(4);
+        hmilyParticipantUndo.setTransId(transactionId);
+        hmilyParticipantUndo.setParticipantId(particaipantId);
+        hmilyParticipantUndo.setUndoId(undoId);
+        return hmilyParticipantUndo;
+    }
+
+    private HmilyParticipant buildHmilyParticipant(Long transactionId, Long particaipantId) {
+        HmilyParticipant hmilyParticipant = new HmilyParticipant();
+        hmilyParticipant.setParticipantId(particaipantId);
+        hmilyParticipant.setTransId(transactionId);
+        hmilyParticipant.setAppName(appName);
+        hmilyParticipant.setParticipantRefId((long) random.nextInt(1000));
+        hmilyParticipant.setStatus(3);
+        hmilyParticipant.setTransType(TransTypeEnum.TCC.name());
+        return hmilyParticipant;
+    }
+
+    private HmilyTransaction buildHmilyTransaction(Long transactionId) {
+        HmilyTransaction hmilyTransaction = new HmilyTransaction();
+        hmilyTransaction.setAppName(appName);
+        hmilyTransaction.setTransId(transactionId);
+        hmilyTransaction.setStatus(4);
+        hmilyTransaction.setRetry(0);
+        hmilyTransaction.setTransType(TransTypeEnum.TCC.name());
+        return hmilyTransaction;
+    }
+}


### PR DESCRIPTION
事务日志zookeeper实现
1. 路径设计： /hmily/appname/{表名}/id  每个id节点即为一条数据
2. 条件查询： 遍历查询
3. updateTime使用程序写入时间
4. 数据中的version与节点version保持一致