### PR TITLE
事务日志fileRepository实现

### DIFF
--- a/hmily-repository/hmily-repository-file/pom.xml
+++ b/hmily-repository/hmily-repository-file/pom.xml
@@ -37,6 +37,11 @@
 
         <dependency>
             <groupId>org.dromara</groupId>
+            <artifactId>hmily-serializer-all</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.dromara</groupId>
             <artifactId>hmily-common</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/hmily-repository/hmily-repository-file/src/main/java/org/dromara/hmily/repository/file/FileRepository.java
+++ b/hmily-repository/hmily-repository-file/src/main/java/org/dromara/hmily/repository/file/FileRepository.java
@@ -18,9 +18,18 @@
 package org.dromara.hmily.repository.file;
 
 import java.io.File;
-import java.util.Date;
-import java.util.List;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.*;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import com.google.common.collect.Lists;
+import lombok.SneakyThrows;
+import org.dromara.hmily.common.exception.HmilyException;
 import org.dromara.hmily.common.exception.HmilyRuntimeException;
+import org.dromara.hmily.common.utils.CollectionUtils;
 import org.dromara.hmily.config.api.ConfigEnv;
 import org.dromara.hmily.config.api.entity.HmilyFileConfig;
 import org.dromara.hmily.repository.spi.HmilyRepository;
@@ -29,147 +38,424 @@ import org.dromara.hmily.repository.spi.entity.HmilyParticipantUndo;
 import org.dromara.hmily.repository.spi.entity.HmilyTransaction;
 import org.dromara.hmily.repository.spi.exception.HmilyRepositoryException;
 import org.dromara.hmily.serializer.spi.HmilySerializer;
+import org.dromara.hmily.serializer.spi.exception.HmilySerializerException;
 import org.dromara.hmily.spi.HmilySPI;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * file impl.
  *
  * @author xiaoyu
+ *
+ * @author choviwu
  */
 @SuppressWarnings("all")
 @HmilySPI("file")
 public class FileRepository implements HmilyRepository {
-    
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(FileRepository.class);
+
     private static volatile boolean initialized;
-    
+
     private String filePath;
-    
+
+    private static final String HMILY_TRANSATION_FILE_DIRECTORY = "hmily_transaction_global";
+
+    private static final String HMILY_TRANSATION_PARTICIPANT_FILE_DIRECTORY = "hmily_transaction_participant";
+
+    private static final String HMILY_PARTICIPANT_UNDO = "hmily_participant_undo";
+
+    private static final int HMILY_READ_BYTE_SIZE = 2048;
+
     private HmilySerializer hmilySerializer;
-    
+
+    private static final ReentrantReadWriteLock LOCK = new ReentrantReadWriteLock();
+
     private String appName;
-    
+
+
     @Override
     public void init(final String appName) {
         this.appName = appName;
         HmilyFileConfig fileConfig = ConfigEnv.getInstance().getConfig(HmilyFileConfig.class);
+        fileConfig.setPath(fileConfig.getPath());
         filePath = fileConfig.getPath();
-        File file = new File(filePath);
-        if (!file.exists()) {
-            file.getParentFile().mkdirs();
-            file.mkdirs();
-        }
+        makeDir();
     }
-    
+
     @Override
     public void setSerializer(final HmilySerializer hmilySerializer) {
         this.hmilySerializer = hmilySerializer;
     }
-    
+
+    @SneakyThrows
     @Override
     public int createHmilyTransaction(HmilyTransaction hmilyTransaction) throws HmilyRepositoryException {
-        return 0;
+        File file = new File(getTransationPath());
+        try {
+
+            final boolean exsist = isExsist(file, hmilyTransaction.getTransId());
+            if (!exsist) {
+                hmilyTransaction.setRetry(0);
+                hmilyTransaction.setVersion(0);
+                hmilyTransaction.setCreateTime(new Date());
+                hmilyTransaction.setUpdateTime(new Date());
+                createOrUpdateWriteFile(file, hmilyTransaction);
+            } else {
+                hmilyTransaction.setVersion(hmilyTransaction.getVersion() + 1);
+                hmilyTransaction.setUpdateTime(new Date());
+                createOrUpdateWriteFile(file, hmilyTransaction);
+            }
+            return HmilyRepository.ROWS;
+        } catch (IOException e) {
+            throw new HmilyException(e);
+        }
     }
-    
+
     @Override
     public int updateRetryByLock(HmilyTransaction hmilyTransaction) {
-        return 0;
+        final int currentVersion = hmilyTransaction.getVersion();
+        File file = new File(getTransationPath());
+        try {
+            final boolean exsist = isExsist(file, hmilyTransaction.getTransId());
+            if (!exsist) {
+                return HmilyRepository.FAIL_ROWS;
+            }
+
+            hmilyTransaction.setVersion(currentVersion + 1);
+            hmilyTransaction.setRetry(hmilyTransaction.getRetry() + 1);
+            hmilyTransaction.setUpdateTime(new Date());
+            createOrUpdateWriteFile(file, hmilyTransaction);
+            return HmilyRepository.ROWS;
+        } catch (IOException e) {
+            LOGGER.error("updateRetryByLock occur a exception", e);
+        }
+        return HmilyRepository.FAIL_ROWS;
     }
-    
+
     @Override
     public HmilyTransaction findByTransId(Long transId) {
+        File file = new File(getTransationPath());
+        boolean exsist = isExsist(file, transId);
+        if (exsist) {
+            return readFile(file, HmilyTransaction.class, transId);
+        }
         return null;
     }
-    
+
+
     @Override
     public List<HmilyTransaction> listLimitByDelay(Date date, int limit) {
-        return null;
+        File file = new File(getTransationPath());
+        return listByFilter(file, HmilyTransaction.class, (hmilyTransaction, params) -> {
+            Date dateParam = (Date) params[0];
+            int limitParam = (int) params[1];
+            boolean filterResult = dateParam.before(hmilyTransaction.getUpdateTime())
+                    && appName.equals(hmilyTransaction.getAppName())
+                    && limitParam-- > 0;
+            // write back to params
+            params[1] = limitParam;
+            return filterResult;
+        }, date, limit);
     }
-    
+
     @Override
     public int updateHmilyTransactionStatus(Long transId, Integer status) throws HmilyRepositoryException {
-        return 0;
+        File file = new File(getTransationPath());
+        try {
+            boolean exsist = isExsist(file, transId);
+            if (!exsist) {
+                return HmilyRepository.FAIL_ROWS;
+            }
+            HmilyTransaction hmilyTransaction = readFile(file, HmilyTransaction.class, transId);
+
+            if (hmilyTransaction == null) {
+                return HmilyRepository.FAIL_ROWS;
+            }
+            hmilyTransaction.setStatus(status);
+            hmilyTransaction.setVersion(hmilyTransaction.getVersion() + 1);
+            hmilyTransaction.setUpdateTime(new Date());
+            createOrUpdateWriteFile(file, hmilyTransaction);
+            return HmilyRepository.ROWS;
+        } catch (IOException e) {
+            LOGGER.error("updateHmilyTransactionStatus occur a exception", e);
+        }
+        return HmilyRepository.FAIL_ROWS;
     }
-    
+
     @Override
     public int removeHmilyTransaction(Long transId) {
-        return 0;
+        File file = new File(getTransationPath());
+        try {
+            boolean exsist = isExsist(file, transId);
+            if (!exsist) {
+                return HmilyRepository.FAIL_ROWS;
+            }
+            HmilyTransaction hmilyTransaction = readFile(file, HmilyTransaction.class, transId);
+
+            if (hmilyTransaction == null) {
+                return HmilyRepository.FAIL_ROWS;
+            }
+            boolean delete = deleteFile(file, transId);
+            return delete ? HmilyRepository.ROWS : HmilyRepository.FAIL_ROWS;
+        } catch (IOException e) {
+            LOGGER.error("updateHmilyTransactionStatus occur a exception", e);
+        }
+        return HmilyRepository.FAIL_ROWS;
     }
-    
+
     @Override
     public int removeHmilyTransactionByData(Date date) {
-        return 0;
+        File file = new File(getTransationPath());
+        return removeByFilter(file, HmilyTransaction.class, (hmilyTransaction, params) -> {
+            Date dateParam = (Date) params[0];
+            return dateParam.before(hmilyTransaction.getUpdateTime()) && hmilyTransaction.getStatus() == 4;
+        }, date);
     }
-    
+
     @Override
     public int createHmilyParticipant(HmilyParticipant hmilyParticipant) throws HmilyRepositoryException {
-        return 0;
+        File file = new File(getTransationParticipantPath());
+        try {
+
+            boolean exsist = isExsist(file, hmilyParticipant.getTransId());
+            if (!exsist) {
+                hmilyParticipant.setRetry(0);
+                hmilyParticipant.setVersion(0);
+                hmilyParticipant.setCreateTime(new Date());
+                hmilyParticipant.setUpdateTime(new Date());
+                createOrUpdateParticipantWriteFile(file, hmilyParticipant);
+            } else {
+                hmilyParticipant.setVersion(hmilyParticipant.getVersion() + 1);
+                hmilyParticipant.setUpdateTime(new Date());
+                createOrUpdateParticipantWriteFile(file, hmilyParticipant);
+            }
+            return HmilyRepository.ROWS;
+        } catch (IOException e) {
+            throw new HmilyException(e);
+        }
     }
-    
+
     @Override
     public List<HmilyParticipant> findHmilyParticipant(Long participantId) {
-        return null;
+        File file = new File(getTransationParticipantPath());
+        return listByFilter(file, HmilyParticipant.class, (hmilyParticipant, params) -> {
+            Long participantIdParam = (Long) params[0];
+            return participantIdParam.compareTo(hmilyParticipant.getParticipantId()) == 0
+                    || (hmilyParticipant.getParticipantRefId() != null && participantIdParam.compareTo(hmilyParticipant.getParticipantRefId()) == 0);
+        }, participantId);
     }
-    
+
     @Override
     public List<HmilyParticipant> listHmilyParticipant(Date date, String transType, int limit) {
-        return null;
+        File file = new File(getTransationParticipantPath());
+        return listByFilter(file, HmilyParticipant.class, (hmilyParticipant, params) -> {
+            Date dateParam = (Date) params[0];
+            String transTypeParam = (String) params[1];
+            int limitParam = (int) params[2];
+            boolean filterResult = dateParam.before(hmilyParticipant.getUpdateTime())
+                    && Objects.equals(appName, hmilyParticipant.getAppName())
+                    && transTypeParam.equals(hmilyParticipant.getTransType())
+                    && (hmilyParticipant.getStatus().compareTo(4) != 0 && hmilyParticipant.getStatus().compareTo(8) != 0)
+                    && limitParam-- > 0;
+            params[2] = limitParam;
+            return filterResult;
+        }, date, transType, limit);
     }
-    
+
     @Override
     public List<HmilyParticipant> listHmilyParticipantByTransId(Long transId) {
-        return null;
+        File file = new File(getTransationParticipantPath());
+        return listByFilter(file, HmilyParticipant.class,
+                (hmilyParticipant, params) -> transId.compareTo(hmilyParticipant.getTransId()) == 0, transId);
     }
-    
+
     @Override
     public boolean existHmilyParticipantByTransId(Long transId) {
-        return false;
+        return existByFilter((hmilyParticipant, params) -> {
+            Long transIdParam = (Long) params[0];
+            return transIdParam.compareTo(hmilyParticipant.getTransId()) == 0;
+        }, transId);
     }
-    
+
     @Override
     public int updateHmilyParticipantStatus(Long participantId, Integer status) throws HmilyRepositoryException {
-        return 0;
+        File file = new File(getTransationParticipantPath());
+        try {
+            boolean exsist = isExsist(file, participantId);
+            if (!exsist) {
+                return HmilyRepository.FAIL_ROWS;
+            }
+            HmilyParticipant hmilyParticipant = readFile(file, HmilyParticipant.class, participantId);
+            if (hmilyParticipant == null) {
+                return HmilyRepository.FAIL_ROWS;
+            }
+
+            hmilyParticipant.setStatus(status);
+            hmilyParticipant.setVersion(hmilyParticipant.getVersion() + 1);
+            hmilyParticipant.setUpdateTime(new Date());
+            createOrUpdateParticipantWriteFile(file, hmilyParticipant);
+            return HmilyRepository.ROWS;
+        } catch (IOException e) {
+            LOGGER.error("updateHmilyParticipantStatus occur a exception", e);
+        }
+        return HmilyRepository.FAIL_ROWS;
     }
-    
+
     @Override
     public int removeHmilyParticipant(Long participantId) {
-        return 0;
+        File file = new File(getTransationParticipantPath());
+        try {
+            boolean exsist = isExsist(file, participantId);
+            if (!exsist) {
+                return HmilyRepository.FAIL_ROWS;
+            }
+            HmilyParticipant hmilyParticipant = readFile(file, HmilyParticipant.class, participantId);
+
+            if (hmilyParticipant == null) {
+                return HmilyRepository.FAIL_ROWS;
+            }
+            boolean delete = deleteFile(file, participantId);
+            return delete ? HmilyRepository.ROWS : HmilyRepository.FAIL_ROWS;
+        } catch (IOException e) {
+            LOGGER.error("updateHmilyTransactionStatus occur a exception", e);
+        }
+        return HmilyRepository.FAIL_ROWS;
     }
-    
+
     @Override
     public int removeHmilyParticipantByData(Date date) {
-        return 0;
+        File file = new File(getTransationParticipantPath());
+        return removeByFilter(file, HmilyParticipant.class, (hmilyParticipant, params) -> {
+            Date dateParam = (Date) params[0];
+            return dateParam.before(hmilyParticipant.getUpdateTime()) && hmilyParticipant.getStatus() == 4;
+        }, date);
     }
-    
+
     @Override
     public boolean lockHmilyParticipant(HmilyParticipant hmilyParticipant) {
+        final int currentVersion = hmilyParticipant.getVersion();
+        File file = new File(getTransationParticipantPath());
+        try {
+            boolean exsist = isExsist(file, hmilyParticipant.getParticipantId());
+            if (!exsist) {
+                LOGGER.warn("path {} is not exists.", file.getPath());
+                return false;
+            }
+
+            hmilyParticipant.setVersion(currentVersion + 1);
+            hmilyParticipant.setRetry(hmilyParticipant.getRetry() + 1);
+            hmilyParticipant.setUpdateTime(new Date());
+            createOrUpdateParticipantWriteFile(file, hmilyParticipant);
+            return true;
+        } catch (IOException e) {
+            LOGGER.error("updateRetryByLock occur a exception", e);
+        }
         return false;
     }
-    
+
     @Override
     public int createHmilyParticipantUndo(HmilyParticipantUndo hmilyParticipantUndo) {
-        return 0;
+        File file = new File(getParticipantUndoPath());
+        try {
+            boolean exsist = isExsist(file, hmilyParticipantUndo.getUndoId());
+            if (!exsist) {
+                hmilyParticipantUndo.setCreateTime(new Date());
+                hmilyParticipantUndo.setUpdateTime(new Date());
+                createOrUpdateParticipantUndoWriteFile(file, hmilyParticipantUndo);
+            } else {
+                hmilyParticipantUndo.setUpdateTime(new Date());
+
+                createOrUpdateParticipantUndoWriteFile(file, hmilyParticipantUndo);
+            }
+            return HmilyRepository.ROWS;
+        } catch (IOException e) {
+            throw new HmilyException(e);
+        }
     }
-    
+
     @Override
     public List<HmilyParticipantUndo> findHmilyParticipantUndoByParticipantId(Long participantId) {
-        return null;
+        File file = new File(getParticipantUndoPath());
+        return listByFilter(file, HmilyParticipantUndo.class, (undo, params) -> {
+            Long participantIdParam = (Long) params[0];
+            return participantIdParam.compareTo(undo.getParticipantId()) == 0;
+        }, participantId);
     }
-    
+
     @Override
     public int removeHmilyParticipantUndo(Long undoId) {
-        return 0;
+        File file = new File(getParticipantUndoPath());
+        try {
+            boolean exsist = isExsist(file, undoId);
+            if (!exsist) {
+                return HmilyRepository.FAIL_ROWS;
+            }
+            HmilyParticipantUndo hmilyParticipantUndo = readFile(file, HmilyParticipantUndo.class, undoId);
+
+            if (hmilyParticipantUndo == null) {
+                return HmilyRepository.FAIL_ROWS;
+            }
+            boolean delete = deleteFile(file, undoId);
+            return delete ? HmilyRepository.ROWS : HmilyRepository.FAIL_ROWS;
+        } catch (IOException e) {
+            LOGGER.error("updateHmilyTransactionStatus occur a exception", e);
+        }
+        return HmilyRepository.FAIL_ROWS;
     }
-    
+
     @Override
     public int removeHmilyParticipantUndoByData(Date date) {
-        return 0;
+        File file = new File(getParticipantUndoPath());
+        return removeByFilter(file, HmilyParticipantUndo.class, (undo, params) -> {
+            Date dateParam = (Date) params[0];
+            return dateParam.before(undo.getUpdateTime()) && undo.getStatus().compareTo(4) == 0;
+        }, date);
     }
-    
+
     @Override
     public int updateHmilyParticipantUndoStatus(Long undoId, Integer status) {
-        return 0;
+        File file = new File(getParticipantUndoPath());
+        try {
+            boolean exsist = isExsist(file, undoId);
+            if (!exsist) {
+                return HmilyRepository.FAIL_ROWS;
+            }
+            HmilyParticipantUndo hmilyParticipantUndo = readFile(file, HmilyParticipantUndo.class, undoId);
+            hmilyParticipantUndo.setStatus(status);
+            hmilyParticipantUndo.setUpdateTime(new Date());
+            createOrUpdateParticipantUndoWriteFile(file, hmilyParticipantUndo);
+            return HmilyRepository.ROWS;
+        } catch (IOException e) {
+            LOGGER.error("updateHmilyParticipantStatus occur a exception", e);
+        }
+
+        return HmilyRepository.FAIL_ROWS;
     }
-    
+
+    /**
+     * transation Path
+     */
+    private String getTransationPath() {
+        return filePath + File.separator + HMILY_TRANSATION_FILE_DIRECTORY;
+    }
+
+    /**
+     * transation participant Path
+     */
+    private String getTransationParticipantPath() {
+        return filePath + File.separator + HMILY_TRANSATION_PARTICIPANT_FILE_DIRECTORY;
+    }
+
+    /**
+     * participantUndo Path
+     */
+    private String getParticipantUndoPath() {
+        return filePath + File.separator + HMILY_PARTICIPANT_UNDO;
+    }
+
+
     private void makeDir() {
         if (!initialized) {
             synchronized (FileRepository.class) {
@@ -180,12 +466,225 @@ public class FileRepository implements HmilyRepository {
                         if (!result) {
                             throw new HmilyRuntimeException("cannot create root path, the path to create is:" + filePath);
                         }
+                        initDir();
                         initialized = true;
                     } else if (!rootPathFile.isDirectory()) {
                         throw new HmilyRuntimeException("rootPath is not directory");
+                    }else{
+                        initDir();
                     }
                 }
             }
         }
     }
+
+    private void initDir(){
+        File transationFileDir = new File(getTransationPath());
+        if (!transationFileDir.exists()) {
+            transationFileDir.getParentFile().mkdirs();
+            boolean mkdirs = transationFileDir.mkdirs();
+            if(!mkdirs){
+                throw new HmilyRuntimeException("cannot create root path, the path to create is:" + transationFileDir.getAbsolutePath());
+            }
+        }
+        File participantFileDir = new File(getTransationParticipantPath());
+        if (!participantFileDir.exists()) {
+            participantFileDir.getParentFile().mkdirs();
+            boolean mkdirs = participantFileDir.mkdirs();
+            if(!mkdirs){
+                throw new HmilyRuntimeException("cannot create root path, the path to create is:" + participantFileDir.getAbsolutePath());
+            }
+        }
+        File participantUndoFileDir = new File(getParticipantUndoPath());
+        if (!participantUndoFileDir.exists()) {
+            participantUndoFileDir.getParentFile().mkdirs();
+            boolean mkdirs = participantUndoFileDir.mkdirs();
+            if(!mkdirs){
+                throw new HmilyRuntimeException("cannot create root path, the path to create is:" + participantUndoFileDir.getAbsolutePath());
+            }
+        }
+    }
+
+    /**
+     * curent transation file exsist
+     * @param file  curent parentFileDir
+     * @param transId transId
+     * @return isExsist
+     */
+    private boolean isExsist(File file, final Long transId) {
+        boolean exsist = Arrays.asList(file.listFiles())
+                .stream().filter(c -> Objects.equals(String.valueOf(transId), c.getName()))
+                .findFirst().isPresent();
+        return exsist;
+    }
+
+    private void createOrUpdateWriteFile(final File file, final HmilyTransaction hmilyTransaction) throws IOException {
+        FileOutputStream fos = null;
+        LOCK.writeLock().lock();
+        try {
+            File curFile = new File(file.getAbsolutePath() + File.separator + hmilyTransaction.getTransId());
+            if (!curFile.exists()) {
+                boolean newFile = curFile.createNewFile();
+            }
+            fos = new FileOutputStream(curFile);
+            fos.write(hmilySerializer.serialize(hmilyTransaction));
+        } finally {
+            if(fos!=null){
+                fos.close();
+            }
+            LOCK.writeLock().unlock();
+        }
+    }
+
+
+    private void createOrUpdateParticipantWriteFile(final File file, final HmilyParticipant hmilyParticipant) throws IOException {
+        FileOutputStream fos = null;
+        LOCK.writeLock().lock();
+        try {
+            File curFile = new File(file.getAbsolutePath() + File.separator + hmilyParticipant.getParticipantId());
+            if (!curFile.exists()) {
+                boolean newFile = curFile.createNewFile();
+            }
+            fos = new FileOutputStream(curFile);
+            fos.write(hmilySerializer.serialize(hmilyParticipant));
+        } finally {
+            if(fos!=null){
+                fos.close();
+            }
+            LOCK.writeLock().unlock();
+        }
+    }
+
+
+    private void createOrUpdateParticipantUndoWriteFile(final File file, final HmilyParticipantUndo hmilyParticipantUndo) throws IOException {
+        FileOutputStream fos = null;
+        LOCK.writeLock().lock();
+        try {
+            File curFile = new File(file.getAbsolutePath() + File.separator + hmilyParticipantUndo.getUndoId());
+            if (!curFile.exists()) {
+                boolean newFile = curFile.createNewFile();
+            }
+            fos = new FileOutputStream(curFile);
+            fos.write(hmilySerializer.serialize(hmilyParticipantUndo));
+        } finally {
+            if(fos!=null){
+                fos.close();
+            }
+            LOCK.writeLock().unlock();
+        }
+    }
+
+
+    private boolean deleteFile(final File file, final Long transId) throws IOException {
+        File curFile = new File(file.getAbsolutePath() + File.separator + transId);
+        if (!curFile.exists()) {
+            return true;
+        }
+        return curFile.delete();
+    }
+
+    /**
+     * read file from cur dir
+     * @return
+     */
+    @SneakyThrows
+    private <T> T readFile(final File file, Class<T> clazz, final Long transId) {
+        LOCK.readLock().lock();
+        FileInputStream fis = null;
+        try {
+            File curFile = new File(file.getAbsolutePath() + File.separator + transId);
+            if (!curFile.exists()) {
+                return null;
+            }
+            fis = new FileInputStream(curFile);
+            byte[] bytes = new byte[HMILY_READ_BYTE_SIZE];
+            fis.read(bytes);
+            return hmilySerializer.deSerialize(bytes, clazz);
+        } catch (IOException | HmilySerializerException e) {
+            LOGGER.error(" read file exception ,because is {}", e);
+            return null;
+        }finally {
+            if(fis!=null){
+                fis.close();
+            }
+            LOCK.readLock().unlock();
+        }
+    }
+
+
+    private <T> List<T> listByFilter(final File file, final Class<T> deserializeClass, final Filter<T> filter, final Object... params) {
+
+        try {
+
+            File[] files = file.listFiles();
+            if (Objects.isNull(files) || files.length <= 0) {
+                return Collections.emptyList();
+            }
+
+            List<T> result = new ArrayList<>();
+            for (File child : files) {
+                T t = readFile(file, deserializeClass, Long.valueOf(child.getName()));
+                if (t == null) {
+                    continue;
+                }
+                if (filter.filter(t, params)) {
+                    result.add(t);
+                }
+            }
+            return result;
+        } catch (Exception e) {
+            LOGGER.error("listByFilter occur a exception", e);
+        }
+        return Collections.emptyList();
+    }
+
+    private <T> boolean existByFilter(final Filter<HmilyParticipant> filter, final Object... params) {
+        File file = new File(getTransationParticipantPath());
+        File[] files = file.listFiles();
+        if (Objects.isNull(files) || files.length <= 0) {
+            return false;
+        }
+
+        for (File child : files) {
+            HmilyParticipant hmilyParticipant = readFile(file, HmilyParticipant.class, Long.valueOf(child.getName()));
+            if (hmilyParticipant == null) {
+                continue;
+            }
+
+            if (filter.filter(hmilyParticipant, params)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private <T> int removeByFilter(final File file, final Class<T> deserializeClass, final Filter<T> filter, final Object... params) {
+
+        File[] files = file.listFiles();
+        if (Objects.isNull(files) || files.length <= 0) {
+            return HmilyRepository.FAIL_ROWS;
+        }
+
+        int count = 0;
+        for (File childFiles : files) {
+            T t = readFile(file, deserializeClass, Long.parseLong(childFiles.getName()));
+            if (t == null) {
+                continue;
+            }
+
+            if (filter.filter(t, params)) {
+                childFiles.delete();
+                count++;
+            }
+        }
+        return count;
+    }
+
+
+    interface Filter<T> {
+
+        boolean filter(T t, Object... params);
+    }
+
+
 }

--- a/hmily-repository/hmily-repository-file/src/main/java/org/dromara/hmily/repository/file/FileRepository.java
+++ b/hmily-repository/hmily-repository-file/src/main/java/org/dromara/hmily/repository/file/FileRepository.java
@@ -20,6 +20,7 @@ package org.dromara.hmily.repository.file;
 import lombok.SneakyThrows;
 import org.dromara.hmily.common.exception.HmilyException;
 import org.dromara.hmily.common.exception.HmilyRuntimeException;
+import org.dromara.hmily.common.utils.LogUtil;
 import org.dromara.hmily.config.api.ConfigEnv;
 import org.dromara.hmily.config.api.entity.HmilyFileConfig;
 import org.dromara.hmily.repository.spi.HmilyRepository;
@@ -130,7 +131,7 @@ public class FileRepository implements HmilyRepository {
             createOrUpdateWriteFile(file, hmilyTransaction);
             return HmilyRepository.ROWS;
         } catch (IOException e) {
-            LOGGER.error("updateRetryByLock occur a exception", e);
+            LogUtil.error(LOGGER, "updateRetryByLock occur a exception {}", () -> e);
         }
         return HmilyRepository.FAIL_ROWS;
     }
@@ -180,7 +181,7 @@ public class FileRepository implements HmilyRepository {
             createOrUpdateWriteFile(file, hmilyTransaction);
             return HmilyRepository.ROWS;
         } catch (IOException e) {
-            LOGGER.error("updateHmilyTransactionStatus occur a exception", e);
+            LogUtil.error(LOGGER, "updateHmilyTransactionStatus occur a exception {}", () -> e);
         }
         return HmilyRepository.FAIL_ROWS;
     }
@@ -201,7 +202,7 @@ public class FileRepository implements HmilyRepository {
             boolean delete = deleteFile(file, transId);
             return delete ? HmilyRepository.ROWS : HmilyRepository.FAIL_ROWS;
         } catch (IOException e) {
-            LOGGER.error("updateHmilyTransactionStatus occur a exception", e);
+            LogUtil.error(LOGGER, "updateHmilyTransactionStatus occur a exception {}", () -> e);
         }
         return HmilyRepository.FAIL_ROWS;
     }
@@ -299,7 +300,7 @@ public class FileRepository implements HmilyRepository {
             createOrUpdateParticipantWriteFile(file, hmilyParticipant);
             return HmilyRepository.ROWS;
         } catch (IOException e) {
-            LOGGER.error("updateHmilyParticipantStatus occur a exception", e);
+            LogUtil.error(LOGGER, "updateHmilyParticipantStatus occur a exception {}", () -> e);
         }
         return HmilyRepository.FAIL_ROWS;
     }
@@ -320,7 +321,7 @@ public class FileRepository implements HmilyRepository {
             boolean delete = deleteFile(file, participantId);
             return delete ? HmilyRepository.ROWS : HmilyRepository.FAIL_ROWS;
         } catch (IOException e) {
-            LOGGER.error("updateHmilyTransactionStatus occur a exception", e);
+            LogUtil.error(LOGGER, "updateHmilyTransactionStatus occur a exception {}", () -> e);
         }
         return HmilyRepository.FAIL_ROWS;
     }
@@ -341,7 +342,7 @@ public class FileRepository implements HmilyRepository {
         try {
             boolean exsist = isExsist(file, hmilyParticipant.getParticipantId());
             if (!exsist) {
-                LOGGER.warn("path {} is not exists.", file.getPath());
+                LogUtil.warn(LOGGER, "path {} is not exists.", () -> file.getPath());
                 return false;
             }
 
@@ -351,7 +352,7 @@ public class FileRepository implements HmilyRepository {
             createOrUpdateParticipantWriteFile(file, hmilyParticipant);
             return true;
         } catch (IOException e) {
-            LOGGER.error("updateRetryByLock occur a exception", e);
+            LogUtil.error(LOGGER, "updateRetryByLock occur a exception {}", () -> e);
         }
         return false;
     }
@@ -401,7 +402,7 @@ public class FileRepository implements HmilyRepository {
             boolean delete = deleteFile(file, undoId);
             return delete ? HmilyRepository.ROWS : HmilyRepository.FAIL_ROWS;
         } catch (IOException e) {
-            LOGGER.error("updateHmilyTransactionStatus occur a exception", e);
+            LogUtil.error(LOGGER, "updateHmilyTransactionStatus occur a exception {}", () -> e);
         }
         return HmilyRepository.FAIL_ROWS;
     }
@@ -429,7 +430,7 @@ public class FileRepository implements HmilyRepository {
             createOrUpdateParticipantUndoWriteFile(file, hmilyParticipantUndo);
             return HmilyRepository.ROWS;
         } catch (IOException e) {
-            LOGGER.error("updateHmilyParticipantStatus occur a exception", e);
+            LogUtil.error(LOGGER, "updateHmilyParticipantStatus occur a exception {}", () -> e);
         }
 
         return HmilyRepository.FAIL_ROWS;
@@ -488,7 +489,7 @@ public class FileRepository implements HmilyRepository {
             transationFileDir.getParentFile().mkdirs();
             boolean mkdirs = transationFileDir.mkdirs();
             if (!mkdirs) {
-                throw new HmilyRuntimeException("cannot create root path, the path to create is:" + transationFileDir.getAbsolutePath());
+                throw new HmilyRuntimeException("cannot create transationFile path, the path to create is:" + transationFileDir.getAbsolutePath());
             }
         }
         File participantFileDir = new File(getTransationParticipantPath());
@@ -496,7 +497,7 @@ public class FileRepository implements HmilyRepository {
             participantFileDir.getParentFile().mkdirs();
             boolean mkdirs = participantFileDir.mkdirs();
             if (!mkdirs) {
-                throw new HmilyRuntimeException("cannot create root path, the path to create is:" + participantFileDir.getAbsolutePath());
+                throw new HmilyRuntimeException("cannot create participantFile path, the path to create is:" + participantFileDir.getAbsolutePath());
             }
         }
         File participantUndoFileDir = new File(getParticipantUndoPath());
@@ -504,7 +505,7 @@ public class FileRepository implements HmilyRepository {
             participantUndoFileDir.getParentFile().mkdirs();
             boolean mkdirs = participantUndoFileDir.mkdirs();
             if (!mkdirs) {
-                throw new HmilyRuntimeException("cannot create root path, the path to create is:" + participantUndoFileDir.getAbsolutePath());
+                throw new HmilyRuntimeException("cannot create participantUndoFile path, the path to create is:" + participantUndoFileDir.getAbsolutePath());
             }
         }
     }
@@ -522,8 +523,10 @@ public class FileRepository implements HmilyRepository {
                 .findFirst().isPresent();
         return exsist;
     }
+
     /**
      * create or update transation File
+     *
      * @param file
      * @param hmilyParticipantUndo
      * @throws IOException
@@ -545,8 +548,10 @@ public class FileRepository implements HmilyRepository {
             LOCK.writeLock().unlock();
         }
     }
+
     /**
      * create or update participant File
+     *
      * @param file
      * @param hmilyParticipantUndo
      * @throws IOException
@@ -571,6 +576,7 @@ public class FileRepository implements HmilyRepository {
 
     /**
      * create or update participantUndo File
+     *
      * @param file
      * @param hmilyParticipantUndo
      * @throws IOException
@@ -621,7 +627,7 @@ public class FileRepository implements HmilyRepository {
             fis.read(bytes);
             return hmilySerializer.deSerialize(bytes, clazz);
         } catch (IOException | HmilySerializerException e) {
-            LOGGER.error(" read file exception ,because is {}", e);
+            LogUtil.error(LOGGER, " read file exception ,because is {}", () -> e);
             return null;
         } finally {
             if (fis != null) {
@@ -653,7 +659,7 @@ public class FileRepository implements HmilyRepository {
             }
             return result;
         } catch (Exception e) {
-            LOGGER.error("listByFilter occur a exception", e);
+            LogUtil.error(LOGGER, "listByFilter occur a exception {}", () -> e);
         }
         return Collections.emptyList();
     }

--- a/hmily-repository/hmily-repository-file/src/main/java/org/dromara/hmily/repository/file/FileRepository.java
+++ b/hmily-repository/hmily-repository-file/src/main/java/org/dromara/hmily/repository/file/FileRepository.java
@@ -33,7 +33,6 @@ import org.dromara.hmily.serializer.spi.exception.HmilySerializerException;
 import org.dromara.hmily.spi.HmilySPI;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -93,14 +92,12 @@ public class FileRepository implements HmilyRepository {
 
     @SneakyThrows
     @Override
-    public int createHmilyTransaction(HmilyTransaction hmilyTransaction) throws HmilyRepositoryException {
+    public int createHmilyTransaction(final HmilyTransaction hmilyTransaction) throws HmilyRepositoryException {
         File file = new File(getTransationPath());
         try {
 
             final boolean exsist = isExsist(file, hmilyTransaction.getTransId());
             if (!exsist) {
-                hmilyTransaction.setRetry(0);
-                hmilyTransaction.setVersion(0);
                 hmilyTransaction.setCreateTime(new Date());
                 hmilyTransaction.setUpdateTime(new Date());
                 createOrUpdateWriteFile(file, hmilyTransaction);
@@ -116,7 +113,7 @@ public class FileRepository implements HmilyRepository {
     }
 
     @Override
-    public int updateRetryByLock(HmilyTransaction hmilyTransaction) {
+    public int updateRetryByLock(final HmilyTransaction hmilyTransaction) {
         final int currentVersion = hmilyTransaction.getVersion();
         File file = new File(getTransationPath());
         try {
@@ -137,7 +134,7 @@ public class FileRepository implements HmilyRepository {
     }
 
     @Override
-    public HmilyTransaction findByTransId(Long transId) {
+    public HmilyTransaction findByTransId(final Long transId) {
         File file = new File(getTransationPath());
         boolean exsist = isExsist(file, transId);
         if (exsist) {
@@ -148,13 +145,13 @@ public class FileRepository implements HmilyRepository {
 
 
     @Override
-    public List<HmilyTransaction> listLimitByDelay(Date date, int limit) {
+    public List<HmilyTransaction> listLimitByDelay(final Date date, final int limit) {
         File file = new File(getTransationPath());
         return listByFilter(file, HmilyTransaction.class, (hmilyTransaction, params) -> {
             Date dateParam = (Date) params[0];
             int limitParam = (int) params[1];
             boolean filterResult = dateParam.before(hmilyTransaction.getUpdateTime())
-                    && appName.equals(hmilyTransaction.getAppName())
+                    && Objects.equals(appName,hmilyTransaction.getAppName())
                     && limitParam-- > 0;
             // write back to params
             params[1] = limitParam;
@@ -163,7 +160,7 @@ public class FileRepository implements HmilyRepository {
     }
 
     @Override
-    public int updateHmilyTransactionStatus(Long transId, Integer status) throws HmilyRepositoryException {
+    public int updateHmilyTransactionStatus(final Long transId,final  Integer status) throws HmilyRepositoryException {
         File file = new File(getTransationPath());
         try {
             boolean exsist = isExsist(file, transId);
@@ -208,7 +205,7 @@ public class FileRepository implements HmilyRepository {
     }
 
     @Override
-    public int removeHmilyTransactionByData(Date date) {
+    public int removeHmilyTransactionByData(final Date date) {
         File file = new File(getTransationPath());
         return removeByFilter(file, HmilyTransaction.class, (hmilyTransaction, params) -> {
             Date dateParam = (Date) params[0];
@@ -217,14 +214,12 @@ public class FileRepository implements HmilyRepository {
     }
 
     @Override
-    public int createHmilyParticipant(HmilyParticipant hmilyParticipant) throws HmilyRepositoryException {
+    public int createHmilyParticipant(final HmilyParticipant hmilyParticipant) throws HmilyRepositoryException {
         File file = new File(getTransationParticipantPath());
         try {
 
             boolean exsist = isExsist(file, hmilyParticipant.getTransId());
             if (!exsist) {
-                hmilyParticipant.setRetry(0);
-                hmilyParticipant.setVersion(0);
                 hmilyParticipant.setCreateTime(new Date());
                 hmilyParticipant.setUpdateTime(new Date());
                 createOrUpdateParticipantWriteFile(file, hmilyParticipant);
@@ -240,7 +235,7 @@ public class FileRepository implements HmilyRepository {
     }
 
     @Override
-    public List<HmilyParticipant> findHmilyParticipant(Long participantId) {
+    public List<HmilyParticipant> findHmilyParticipant(final Long participantId) {
         File file = new File(getTransationParticipantPath());
         return listByFilter(file, HmilyParticipant.class, (hmilyParticipant, params) -> {
             Long participantIdParam = (Long) params[0];
@@ -250,7 +245,7 @@ public class FileRepository implements HmilyRepository {
     }
 
     @Override
-    public List<HmilyParticipant> listHmilyParticipant(Date date, String transType, int limit) {
+    public List<HmilyParticipant> listHmilyParticipant(final Date date,final  String transType,final  int limit) {
         File file = new File(getTransationParticipantPath());
         return listByFilter(file, HmilyParticipant.class, (hmilyParticipant, params) -> {
             Date dateParam = (Date) params[0];
@@ -267,14 +262,14 @@ public class FileRepository implements HmilyRepository {
     }
 
     @Override
-    public List<HmilyParticipant> listHmilyParticipantByTransId(Long transId) {
+    public List<HmilyParticipant> listHmilyParticipantByTransId(final Long transId) {
         File file = new File(getTransationParticipantPath());
         return listByFilter(file, HmilyParticipant.class,
                 (hmilyParticipant, params) -> transId.compareTo(hmilyParticipant.getTransId()) == 0, transId);
     }
 
     @Override
-    public boolean existHmilyParticipantByTransId(Long transId) {
+    public boolean existHmilyParticipantByTransId(final Long transId) {
         return existByFilter((hmilyParticipant, params) -> {
             Long transIdParam = (Long) params[0];
             return transIdParam.compareTo(hmilyParticipant.getTransId()) == 0;
@@ -282,7 +277,7 @@ public class FileRepository implements HmilyRepository {
     }
 
     @Override
-    public int updateHmilyParticipantStatus(Long participantId, Integer status) throws HmilyRepositoryException {
+    public int updateHmilyParticipantStatus(final Long participantId,final  Integer status) throws HmilyRepositoryException {
         File file = new File(getTransationParticipantPath());
         try {
             boolean exsist = isExsist(file, participantId);
@@ -306,7 +301,7 @@ public class FileRepository implements HmilyRepository {
     }
 
     @Override
-    public int removeHmilyParticipant(Long participantId) {
+    public int removeHmilyParticipant(final Long participantId) {
         File file = new File(getTransationParticipantPath());
         try {
             boolean exsist = isExsist(file, participantId);
@@ -327,7 +322,7 @@ public class FileRepository implements HmilyRepository {
     }
 
     @Override
-    public int removeHmilyParticipantByData(Date date) {
+    public int removeHmilyParticipantByData(final Date date) {
         File file = new File(getTransationParticipantPath());
         return removeByFilter(file, HmilyParticipant.class, (hmilyParticipant, params) -> {
             Date dateParam = (Date) params[0];
@@ -336,7 +331,7 @@ public class FileRepository implements HmilyRepository {
     }
 
     @Override
-    public boolean lockHmilyParticipant(HmilyParticipant hmilyParticipant) {
+    public boolean lockHmilyParticipant(final HmilyParticipant hmilyParticipant) {
         final int currentVersion = hmilyParticipant.getVersion();
         File file = new File(getTransationParticipantPath());
         try {
@@ -358,7 +353,7 @@ public class FileRepository implements HmilyRepository {
     }
 
     @Override
-    public int createHmilyParticipantUndo(HmilyParticipantUndo hmilyParticipantUndo) {
+    public int createHmilyParticipantUndo(final HmilyParticipantUndo hmilyParticipantUndo) {
         File file = new File(getParticipantUndoPath());
         try {
             boolean exsist = isExsist(file, hmilyParticipantUndo.getUndoId());
@@ -378,7 +373,7 @@ public class FileRepository implements HmilyRepository {
     }
 
     @Override
-    public List<HmilyParticipantUndo> findHmilyParticipantUndoByParticipantId(Long participantId) {
+    public List<HmilyParticipantUndo> findHmilyParticipantUndoByParticipantId(final Long participantId) {
         File file = new File(getParticipantUndoPath());
         return listByFilter(file, HmilyParticipantUndo.class, (undo, params) -> {
             Long participantIdParam = (Long) params[0];
@@ -387,7 +382,7 @@ public class FileRepository implements HmilyRepository {
     }
 
     @Override
-    public int removeHmilyParticipantUndo(Long undoId) {
+    public int removeHmilyParticipantUndo(final Long undoId) {
         File file = new File(getParticipantUndoPath());
         try {
             boolean exsist = isExsist(file, undoId);
@@ -408,7 +403,7 @@ public class FileRepository implements HmilyRepository {
     }
 
     @Override
-    public int removeHmilyParticipantUndoByData(Date date) {
+    public int removeHmilyParticipantUndoByData(final Date date) {
         File file = new File(getParticipantUndoPath());
         return removeByFilter(file, HmilyParticipantUndo.class, (undo, params) -> {
             Date dateParam = (Date) params[0];
@@ -417,7 +412,7 @@ public class FileRepository implements HmilyRepository {
     }
 
     @Override
-    public int updateHmilyParticipantUndoStatus(Long undoId, Integer status) {
+    public int updateHmilyParticipantUndoStatus(final Long undoId,final  Integer status) {
         File file = new File(getParticipantUndoPath());
         try {
             boolean exsist = isExsist(file, undoId);
@@ -440,21 +435,21 @@ public class FileRepository implements HmilyRepository {
      * transation Path
      */
     private String getTransationPath() {
-        return filePath + File.separator + HMILY_TRANSATION_FILE_DIRECTORY;
+        return filePath + File.separator + appName +File.separator+ HMILY_TRANSATION_FILE_DIRECTORY;
     }
 
     /**
      * transation participant Path
      */
     private String getTransationParticipantPath() {
-        return filePath + File.separator + HMILY_TRANSATION_PARTICIPANT_FILE_DIRECTORY;
+        return filePath + File.separator + appName +File.separator + HMILY_TRANSATION_PARTICIPANT_FILE_DIRECTORY;
     }
 
     /**
      * participantUndo Path
      */
     private String getParticipantUndoPath() {
-        return filePath + File.separator + HMILY_PARTICIPANT_UNDO;
+        return filePath + File.separator + appName +File.separator + HMILY_PARTICIPANT_UNDO;
     }
 
 
@@ -517,7 +512,7 @@ public class FileRepository implements HmilyRepository {
      * @param transId transId
      * @return isExsist
      */
-    private boolean isExsist(File file, final Long transId) {
+    private boolean isExsist(final File file, final Long transId) {
         boolean exsist = Arrays.asList(file.listFiles())
                 .stream().filter(c -> Objects.equals(String.valueOf(transId), c.getName()))
                 .findFirst().isPresent();
@@ -535,7 +530,7 @@ public class FileRepository implements HmilyRepository {
         FileOutputStream fos = null;
         LOCK.writeLock().lock();
         try {
-            File curFile = new File(file.getAbsolutePath() + File.separator + hmilyTransaction.getTransId());
+            File curFile = new File(concatPath(file.getAbsolutePath(),hmilyTransaction.getTransId()));
             if (!curFile.exists()) {
                 boolean newFile = curFile.createNewFile();
             }
@@ -560,7 +555,7 @@ public class FileRepository implements HmilyRepository {
         FileOutputStream fos = null;
         LOCK.writeLock().lock();
         try {
-            File curFile = new File(file.getAbsolutePath() + File.separator + hmilyParticipant.getParticipantId());
+            File curFile = new File(concatPath(file.getAbsolutePath(),hmilyParticipant.getParticipantId()));
             if (!curFile.exists()) {
                 boolean newFile = curFile.createNewFile();
             }
@@ -585,7 +580,7 @@ public class FileRepository implements HmilyRepository {
         FileOutputStream fos = null;
         LOCK.writeLock().lock();
         try {
-            File curFile = new File(file.getAbsolutePath() + File.separator + hmilyParticipantUndo.getUndoId());
+            File curFile = new File(concatPath(file.getAbsolutePath(),hmilyParticipantUndo.getUndoId()));
             if (!curFile.exists()) {
                 boolean newFile = curFile.createNewFile();
             }
@@ -601,11 +596,15 @@ public class FileRepository implements HmilyRepository {
 
 
     private boolean deleteFile(final File file, final Long transId) throws IOException {
-        File curFile = new File(file.getAbsolutePath() + File.separator + transId);
+        File curFile = new File(concatPath(file.getAbsolutePath(),transId));
         if (!curFile.exists()) {
             return true;
         }
         return curFile.delete();
+    }
+
+    private String concatPath(String filePath,Long id){
+        return filePath + File.separator + id;
     }
 
     /**
@@ -614,11 +613,11 @@ public class FileRepository implements HmilyRepository {
      * @return
      */
     @SneakyThrows
-    private <T> T readFile(final File file, Class<T> clazz, final Long transId) {
+    private <T> T readFile(final File file,final  Class<T> clazz, final Long transId) {
         LOCK.readLock().lock();
         FileInputStream fis = null;
         try {
-            File curFile = new File(file.getAbsolutePath() + File.separator + transId);
+            File curFile = new File(concatPath(file.getAbsolutePath(),transId));
             if (!curFile.exists()) {
                 return null;
             }

--- a/hmily-repository/hmily-repository-file/src/test/java/org/dromara/hmily/repository/file/FileRepositoryTest.java
+++ b/hmily-repository/hmily-repository-file/src/test/java/org/dromara/hmily/repository/file/FileRepositoryTest.java
@@ -1,0 +1,255 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.dromara.hmily.repository.file;
+
+import java.lang.reflect.Field;
+import java.util.Calendar;
+import java.util.List;
+import java.util.Random;
+
+import org.dromara.hmily.annotation.TransTypeEnum;
+import org.dromara.hmily.config.api.Config;
+import org.dromara.hmily.config.api.ConfigEnv;
+import org.dromara.hmily.config.api.entity.HmilyConfig;
+import org.dromara.hmily.config.api.entity.HmilyFileConfig;
+import org.dromara.hmily.repository.spi.entity.HmilyParticipant;
+import org.dromara.hmily.repository.spi.entity.HmilyParticipantUndo;
+import org.dromara.hmily.repository.spi.entity.HmilyTransaction;
+import org.dromara.hmily.serializer.jdk.JDKSerializer;
+import org.dromara.hmily.serializer.kryo.KryoSerializer;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * file repository test unit
+ *
+ * @author choviwu
+ */
+public class FileRepositoryTest {
+    
+    private FileRepository fileRepository = new FileRepository();
+
+    private HmilyConfig hmilyConfig = new HmilyConfig();
+
+    private HmilyFileConfig hmilyFileConfig = new HmilyFileConfig();
+    
+    private String appName = "test-hmily";
+    
+    private Random random = new Random(System.currentTimeMillis());
+    /**
+     * Sets up.
+     *
+     * @throws Exception the exception
+     */
+    @Before
+    public void setUp() throws Exception {
+        hmilyFileConfig.setPath(System.getProperty("hmily.file.path"));
+
+        ConfigEnv.getInstance().putBean(hmilyFileConfig);
+        hmilyConfig.setAppName(appName);
+        
+        fileRepository.init(appName);
+        fileRepository.setSerializer(new JDKSerializer());
+    }
+    
+    /**
+     * Test curd.
+     */
+    @Test
+    public void testCURD() {
+        Long transactionId = (long) random.nextInt(1000);
+        testTransaction(transactionId);
+        
+        Long participantId = (long) random.nextInt(1000);
+        testParticipant(transactionId, participantId);
+        
+        Long undoId = (long) random.nextInt(1000);
+        testParticipantUndo(transactionId, participantId, undoId);
+    }
+    
+    private void testTransaction(Long transactionId) {
+        HmilyTransaction hmilyTransaction = buildHmilyTransaction(transactionId);
+        int result = fileRepository.createHmilyTransaction(hmilyTransaction);
+        assertNotEquals(0L, result);
+        
+        int updateStatusResult = fileRepository.updateHmilyTransactionStatus(hmilyTransaction.getTransId(), 3);
+        assertNotEquals(0L, updateStatusResult);
+        
+        hmilyTransaction.setTransType(TransTypeEnum.TAC.name());
+        hmilyTransaction.setStatus(4);
+        int updateLockResult = fileRepository.updateRetryByLock(hmilyTransaction);
+        assertNotEquals(0L, updateLockResult);
+        
+        
+        
+        HmilyTransaction findTransactionResult = fileRepository.findByTransId(hmilyTransaction.getTransId());
+        assertNotNull(findTransactionResult);
+        assertEquals(appName, findTransactionResult.getAppName());
+        assertEquals(TransTypeEnum.TAC.name(), findTransactionResult.getTransType());
+        assertEquals(4L, findTransactionResult.getStatus());
+        
+        
+        hmilyTransaction = buildHmilyTransaction((long) random.nextInt(1000));
+        result = fileRepository.createHmilyTransaction(hmilyTransaction);
+        assertEquals(1L, result);
+        
+        hmilyTransaction = buildHmilyTransaction((long) random.nextInt(1000));
+        result = fileRepository.createHmilyTransaction(hmilyTransaction);
+        assertEquals(1L, result);
+        
+        hmilyTransaction = buildHmilyTransaction((long) random.nextInt(1000));
+        result = fileRepository.createHmilyTransaction(hmilyTransaction);
+        assertEquals(1L, result);
+        Calendar calendar = Calendar.getInstance();
+        calendar.add(Calendar.HOUR_OF_DAY, -1);
+        List<HmilyTransaction> listTransactionResult = fileRepository.listLimitByDelay(calendar.getTime(), 2);
+        assertNotNull(listTransactionResult);
+        assertNotEquals(0L, listTransactionResult.size());
+        assertEquals(2L, listTransactionResult.size());
+        int removeByIdResult = fileRepository.removeHmilyTransaction(transactionId);
+        assertEquals(1L, removeByIdResult);
+        
+        int removeByDateResult = fileRepository.removeHmilyTransactionByData(calendar.getTime());
+        assertEquals(3L, removeByDateResult);
+    }
+    
+    private void testParticipantUndo(Long transactionId, Long participantId, Long undoId) {
+        int result;
+        HmilyParticipantUndo hmilyParticipantUndo = buildHmilyParticipantUndo(transactionId, participantId, undoId);
+        result = fileRepository.createHmilyParticipantUndo(hmilyParticipantUndo);
+        assertNotEquals(0L, result);
+        
+        
+        int updateStatusResult = fileRepository.updateHmilyParticipantUndoStatus(undoId, 3);
+        assertEquals(1L, updateStatusResult);
+        
+        List<HmilyParticipantUndo> findUndoResult = fileRepository.findHmilyParticipantUndoByParticipantId(hmilyParticipantUndo.getParticipantId());
+        assertNotNull(findUndoResult);
+        assertNotEquals(0L, findUndoResult.size());
+        assertEquals(findUndoResult.get(0).getUndoId(), hmilyParticipantUndo.getUndoId());
+        assertEquals(3L, (long) findUndoResult.get(0).getStatus());
+        
+        
+        int removeByIdResult = fileRepository.removeHmilyParticipantUndo(undoId);
+        assertEquals(1L, removeByIdResult);
+        
+        hmilyParticipantUndo = buildHmilyParticipantUndo(transactionId, participantId, (long) random.nextInt(1000));
+        result = fileRepository.createHmilyParticipantUndo(hmilyParticipantUndo);
+        assertNotEquals(0L, result);
+        hmilyParticipantUndo = buildHmilyParticipantUndo(transactionId, participantId, (long) random.nextInt(1000));
+        result = fileRepository.createHmilyParticipantUndo(hmilyParticipantUndo);
+        assertNotEquals(0L, result);
+        hmilyParticipantUndo = buildHmilyParticipantUndo(transactionId, participantId, (long) random.nextInt(1000));
+        result = fileRepository.createHmilyParticipantUndo(hmilyParticipantUndo);
+        assertNotEquals(0L, result);
+        
+        Calendar calendar = Calendar.getInstance();
+        calendar.add(Calendar.HOUR_OF_DAY, -1);
+        int removeByDateResult = fileRepository.removeHmilyParticipantUndoByData(calendar.getTime());
+        assertEquals(3L, removeByDateResult);
+    }
+    
+    private void testParticipant(Long transactionId, Long participantId) {
+        HmilyParticipant hmilyParticipant = buildHmilyParticipant(transactionId, participantId);
+        int result = fileRepository.createHmilyParticipant(hmilyParticipant);
+        assertNotEquals(0L, result);
+        
+        
+        int updateStatusResult = fileRepository.updateHmilyParticipantStatus(participantId, 5);
+        assertEquals(1L, updateStatusResult);
+        hmilyParticipant.setStatus(4);
+        boolean lockUpdateResult = fileRepository.lockHmilyParticipant(hmilyParticipant);
+        assertTrue(lockUpdateResult);
+        
+        List<HmilyParticipant> findParticipantResult = fileRepository.findHmilyParticipant(hmilyParticipant.getParticipantId());
+        assertNotNull(findParticipantResult);
+        assertNotEquals(0L, findParticipantResult.size());
+        assertTrue(findParticipantResult.get(0).getParticipantId().equals(hmilyParticipant.getParticipantId()) ||
+                findParticipantResult.get(0).getParticipantRefId().equals(hmilyParticipant.getParticipantId()));
+        assertEquals(4L, (long) findParticipantResult.stream()
+                .filter(x -> x.getParticipantId()
+                        .equals(participantId)).findFirst().get().getStatus());
+        
+        Calendar calendar = Calendar.getInstance();
+        calendar.add(Calendar.HOUR_OF_DAY, -1);
+        long id1 = random.nextInt(1000);
+        hmilyParticipant = buildHmilyParticipant(transactionId, id1);
+        result = fileRepository.createHmilyParticipant(hmilyParticipant);
+        assertEquals(1L, result);
+        long id2 = random.nextInt(1000);
+        hmilyParticipant = buildHmilyParticipant(transactionId, id2);
+        result = fileRepository.createHmilyParticipant(hmilyParticipant);
+        assertEquals(1L, result);
+        long id3 = random.nextInt(1000);
+        hmilyParticipant = buildHmilyParticipant(transactionId, id3);
+        result = fileRepository.createHmilyParticipant(hmilyParticipant);
+        assertEquals(1L, result);
+        List<HmilyParticipant> listResult = fileRepository.listHmilyParticipant(calendar.getTime(), TransTypeEnum.TCC.name(), 2);
+        assertEquals(2L, listResult.size());
+        
+        List<HmilyParticipant> listByTransactionIdResult = fileRepository.listHmilyParticipantByTransId(transactionId);
+        assertEquals(4L, listByTransactionIdResult.size());
+        
+        boolean existsRsult = fileRepository.existHmilyParticipantByTransId(transactionId);
+        assertTrue(existsRsult);
+        
+        int removeByIdResult = fileRepository.removeHmilyParticipant(participantId);
+        assertEquals(1L, removeByIdResult);
+        
+        fileRepository.updateHmilyParticipantStatus(id1, 4);
+        fileRepository.updateHmilyParticipantStatus(id2, 4);
+        fileRepository.updateHmilyParticipantStatus(id3, 4);
+        int removeByDateResult = fileRepository.removeHmilyParticipantByData(calendar.getTime());
+        assertEquals(3L, removeByDateResult);
+    }
+    
+    private HmilyParticipantUndo buildHmilyParticipantUndo(Long transactionId, Long particaipantId, Long undoId) {
+        HmilyParticipantUndo hmilyParticipantUndo = new HmilyParticipantUndo();
+        hmilyParticipantUndo.setStatus(4);
+        hmilyParticipantUndo.setTransId(transactionId);
+        hmilyParticipantUndo.setParticipantId(particaipantId);
+        hmilyParticipantUndo.setUndoId(undoId);
+        return hmilyParticipantUndo;
+    }
+    
+    private HmilyParticipant buildHmilyParticipant(Long transactionId, Long particaipantId) {
+        HmilyParticipant hmilyParticipant = new HmilyParticipant();
+        hmilyParticipant.setParticipantId(particaipantId);
+        hmilyParticipant.setTransId(transactionId);
+        hmilyParticipant.setAppName(appName);
+        hmilyParticipant.setParticipantRefId((long) random.nextInt(1000));
+        hmilyParticipant.setStatus(3);
+        hmilyParticipant.setTransType(TransTypeEnum.TCC.name());
+        return hmilyParticipant;
+    }
+    
+    private HmilyTransaction buildHmilyTransaction(Long transactionId) {
+        HmilyTransaction hmilyTransaction = new HmilyTransaction();
+        hmilyTransaction.setAppName(appName);
+        hmilyTransaction.setTransId(transactionId);
+        hmilyTransaction.setStatus(4);
+        hmilyTransaction.setRetry(0);
+        hmilyTransaction.setTransType(TransTypeEnum.TCC.name());
+        return hmilyTransaction;
+    }
+}

--- a/hmily-repository/hmily-repository-file/src/test/java/org/dromara/hmily/repository/file/FileRepositoryTest.java
+++ b/hmily-repository/hmily-repository-file/src/test/java/org/dromara/hmily/repository/file/FileRepositoryTest.java
@@ -69,7 +69,10 @@ public class FileRepositoryTest {
         hmilyConfig.setAppName(appName);
         
         fileRepository.init(appName);
-        fileRepository.setSerializer(new JDKSerializer());
+        fileRepository.setSerializer(new KryoSerializer());
+//        fileRepository.setSerializer(new JDKSerializer());
+//        fileRepository.setSerializer(new JDKSerializer());
+//        fileRepository.setSerializer(new JDKSerializer());
     }
     
     /**


### PR DESCRIPTION
路径设计： /{{自定义路径}}/{表名}/id 每个id文件对应一条事务数据
条件查询： 遍历查询
读写锁保护单个文件的执行有效性