### PR TITLE
repository-zookeeper 添加mock测试

### DIFF
--- a/hmily-repository/hmily-repository-zookeeper/pom.xml
+++ b/hmily-repository/hmily-repository-zookeeper/pom.xml
@@ -27,6 +27,9 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>hmily-repository-zookeeper</artifactId>
+    <properties>
+        <metrics.version>3.2.6</metrics.version>
+    </properties>
 
     <dependencies>
         <dependency>
@@ -51,10 +54,15 @@
             <artifactId>zookeeper</artifactId>
             <exclusions>
                 <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-log4j12</artifactId>
+                    <groupId>com.codahale.metrics</groupId>
+                    <artifactId>metrics-core</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+            <version>${metrics.version}</version>
         </dependency>
     </dependencies>
 

--- a/hmily-repository/hmily-repository-zookeeper/src/test/java/org/dromara/hmily/repository/zookeeper/mock/ZookeeperMock.java
+++ b/hmily-repository/hmily-repository-zookeeper/src/test/java/org/dromara/hmily/repository/zookeeper/mock/ZookeeperMock.java
@@ -1,0 +1,102 @@
+package org.dromara.hmily.repository.zookeeper.mock;
+
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.KeeperException;
+import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.data.ACL;
+import org.apache.zookeeper.data.Stat;
+import org.apache.zookeeper.server.DataNode;
+import org.apache.zookeeper.server.DataTree;
+import org.mockito.Mockito;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
+
+
+/**
+ * Author:   lilang
+ * Date:     2020-08-19 22:18
+ * Description:
+ **/
+public class ZookeeperMock {
+
+    private DataTree dataTree = new DataTree();
+
+    private ZooKeeper zooKeeper = Mockito.mock(ZooKeeper.class);
+
+    public ZooKeeper getZooKeeper() {
+        return this.zooKeeper;
+    }
+
+
+    public void mockCreate() throws KeeperException, InterruptedException {
+        when(zooKeeper.create(anyString(), any(byte[].class), anyList(), eq(CreateMode.PERSISTENT))).then(x -> {
+            String path = x.getArgument(0);
+            byte[] data = x.getArgument(1);
+            List<ACL> aclList = x.getArgument(2);
+            // ephemeralOwner == 0 means permanent node
+            dataTree.createNode(path, data, aclList, 0, 0, 0, System.currentTimeMillis());
+            return "";
+        });
+    }
+
+    public void mockSetData() throws KeeperException, InterruptedException {
+        when(zooKeeper.setData(anyString(), any(byte[].class), anyInt())).then(x -> {
+            String path = x.getArgument(0);
+            byte[] data = x.getArgument(1);
+            int version = x.getArgument(2);
+            checkVersion(path, version);
+            return dataTree.setData(path, data, version, 0, System.currentTimeMillis());
+        });
+    }
+
+    public void mockExists() throws KeeperException, InterruptedException {
+        when(zooKeeper.exists(anyString(), eq(false))).then(x -> {
+            try {
+                return dataTree.statNode(x.getArgument(0), null);
+            } catch (KeeperException.NoNodeException e) {
+                return null;
+            }
+        });
+    }
+
+    public void mockGetChildren() throws KeeperException, InterruptedException {
+        when(zooKeeper.getChildren(anyString(), eq(false))).then(x ->
+                dataTree.getChildren(x.getArgument(0), null, null)
+        );
+    }
+
+    public void mockGetData() throws KeeperException, InterruptedException {
+        when(zooKeeper.getData(anyString(), eq(false), any()))
+                .then(x ->
+                        dataTree.getData(x.getArgument(0), x.getArgument(2) == null ? new Stat() : x.getArgument(2), null));
+    }
+
+    public void mockDelete() throws KeeperException, InterruptedException {
+        // return is void and mock the method
+        doAnswer(x -> {
+            String path = x.getArgument(0);
+            int version = x.getArgument(1);
+            checkVersion(path, version);
+            dataTree.deleteNode(path, 0);
+            return this;
+        }).when(zooKeeper).delete(anyString(), anyInt());
+    }
+
+    private void checkVersion(String path, int version) throws KeeperException.BadVersionException {
+        DataNode node = dataTree.getNode(path);
+        if (node != null) {
+            if (version != -1 && node.stat.getVersion() != version) {
+                throw new KeeperException.BadVersionException();
+            }
+        }
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
         <hamcrest.version>1.3</hamcrest.version>
         <mockito.version>2.7.21</mockito.version>
         <logback.version>1.2.0</logback.version>
+        <powermock.version>2.0.7</powermock.version>
     </properties>
 
     <dependencyManagement>
@@ -135,17 +136,35 @@
             <artifactId>mockito-core</artifactId>
             <version>${mockito.version}</version>
             <scope>test</scope>
-            <exclusions>
+            <!--<exclusions>
                 <exclusion>
                     <groupId>org.hamcrest</groupId>
                     <artifactId>hamcrest-core</artifactId>
                 </exclusion>
-            </exclusions>
+            </exclusions>-->
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
             <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito2</artifactId>
+            <version>${powermock.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>objenesis</artifactId>
+                    <groupId>org.objenesis</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-junit4</artifactId>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <!--        <dependency>-->


### PR DESCRIPTION
1. repository-zookeeper 添加mock测试   
    [使用zookeeper包里面的DataTree数据结构进行mock，好处是zookeeper server也是用的它，测试结果可以更加接近使用 
     zookeeper server测试的结果]
    [metric-core包在zookeeper包的依赖中是provided的，在进行mock测试时，会报NoClassDef错误，所以在模块中添加了metric- 
     core包]
2. 修复removeByFilter bug
3. 添加powermock包（目前使用场景：zookeeper的构造方法拦截）