### PR TITLE
tac 模式增加事务隔离级别的控制

### DIFF
--- a/hmily-annotation/src/main/java/org/dromara/hmily/annotation/HmilyTAC.java
+++ b/hmily-annotation/src/main/java/org/dromara/hmily/annotation/HmilyTAC.java
@@ -30,4 +30,10 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 public @interface HmilyTAC {
 
+    /**
+     * Transaction isolation level enum.
+     *
+     * @return the transaction isolation level enum
+     */
+    IsolationLevelEnum isolationLevel() default IsolationLevelEnum.READ_UNCOMMITTED;
 }

--- a/hmily-annotation/src/main/java/org/dromara/hmily/annotation/IsolationLevelEnum.java
+++ b/hmily-annotation/src/main/java/org/dromara/hmily/annotation/IsolationLevelEnum.java
@@ -1,0 +1,26 @@
+package org.dromara.hmily.annotation;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * The enum Transaction Isolation Level enum.
+ *
+ * @author zhangzhi
+ */
+@AllArgsConstructor
+@Getter
+public enum IsolationLevelEnum {
+
+    /**
+     * read_uncommitted enum.
+     */
+    READ_UNCOMMITTED(0),
+
+    /**
+     * read_committed enum.
+     */
+    READ_COMMITTED(1);
+
+    private final int value;
+}

--- a/hmily-core/src/main/java/org/dromara/hmily/core/context/HmilyTransactionContext.java
+++ b/hmily-core/src/main/java/org/dromara/hmily/core/context/HmilyTransactionContext.java
@@ -17,6 +17,7 @@
 package org.dromara.hmily.core.context;
 
 import lombok.Data;
+import org.dromara.hmily.annotation.IsolationLevelEnum;
 import org.dromara.hmily.common.enums.HmilyActionEnum;
 import org.dromara.hmily.common.enums.HmilyRoleEnum;
 
@@ -57,6 +58,11 @@ public class HmilyTransactionContext {
      * transType.
      */
     private String transType;
+
+    /**
+     * isolation level enum. {@linkplain IsolationLevelEnum}
+     */
+    private int isolationLevel;
 
     //以下为xa相关的参数.
     /**

--- a/hmily-demo/hmily-demo-tac/hmily-demo-tac-dubbo/hmily-demo-tac-dubbo-order/src/main/java/org/dromara/hmily/demo/tac/dubbo/order/service/impl/PaymentServiceImpl.java
+++ b/hmily-demo/hmily-demo-tac/hmily-demo-tac-dubbo/hmily-demo-tac-dubbo-order/src/main/java/org/dromara/hmily/demo/tac/dubbo/order/service/impl/PaymentServiceImpl.java
@@ -17,6 +17,7 @@
 package org.dromara.hmily.demo.tac.dubbo.order.service.impl;
 
 import org.dromara.hmily.annotation.HmilyTAC;
+import org.dromara.hmily.annotation.IsolationLevelEnum;
 import org.dromara.hmily.common.exception.HmilyRuntimeException;
 import org.dromara.hmily.demo.common.account.api.AccountService;
 import org.dromara.hmily.demo.common.account.dto.AccountDTO;
@@ -32,6 +33,7 @@ import org.dromara.hmily.demo.tac.dubbo.order.service.PaymentService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.datasource.IsolationLevelDataSourceAdapter;
 import org.springframework.stereotype.Service;
 
 
@@ -152,9 +154,9 @@ public class PaymentServiceImpl implements PaymentService {
     }
 
     @Override
-    @HmilyTAC
+    @HmilyTAC(isolationLevel = IsolationLevelEnum.READ_COMMITTED) // 开启读已提交隔离级别, 不开启事务会正常结束
     public String makePaymentWithReadCommitted(Order order, ReadCommittedTransactionEnum transactionEnum) {
-        //第二个事务查询相同账户信息, 获取不到全局锁, 会进行回滚
+        //第二个事务查询相同账户信息, 获取不到全局锁, 会先进行重试, 重试完后会进行回滚
         if (ReadCommittedTransactionEnum.TRANSACTION_READ_ONLY.equals(transactionEnum)) {
             accountService.findByUserId(order.getUserId());
             return "success";

--- a/hmily-demo/hmily-demo-tac/hmily-demo-tac-springcloud/hmily-demo-tac-springcloud-order/src/main/java/org/dromara/hmily/demo/springcloud/order/service/impl/PaymentServiceImpl.java
+++ b/hmily-demo/hmily-demo-tac/hmily-demo-tac-springcloud/hmily-demo-tac-springcloud-order/src/main/java/org/dromara/hmily/demo/springcloud/order/service/impl/PaymentServiceImpl.java
@@ -17,6 +17,7 @@
 package org.dromara.hmily.demo.springcloud.order.service.impl;
 
 import org.dromara.hmily.annotation.HmilyTAC;
+import org.dromara.hmily.annotation.IsolationLevelEnum;
 import org.dromara.hmily.common.exception.HmilyRuntimeException;
 import org.dromara.hmily.demo.common.account.dto.AccountDTO;
 import org.dromara.hmily.demo.common.account.dto.AccountNestedDTO;
@@ -153,9 +154,9 @@ public class PaymentServiceImpl implements PaymentService {
     }
 
     @Override
-    @HmilyTAC
+    @HmilyTAC(isolationLevel = IsolationLevelEnum.READ_COMMITTED) // 开启读已提交隔离级别, 不开启事务会正常结束
     public String makePaymentWithReadCommitted(Order order, ReadCommittedTransactionEnum transactionEnum) {
-        //第二个事务查询相同账户信息, 获取不到全局锁, 会进行回滚
+        //第二个事务查询相同账户信息, 获取不到全局锁, 会先进行重试, 重试完后会进行回滚
         if (ReadCommittedTransactionEnum.TRANSACTION_READ_ONLY.equals(transactionEnum)) {
             accountClient.findByUserId(order.getUserId());
             return "success";

--- a/hmily-tac/hmily-tac-core/src/main/java/org/dromara/hmily/tac/core/handler/StarterHmilyTacTransactionHandler.java
+++ b/hmily-tac/hmily-tac-core/src/main/java/org/dromara/hmily/tac/core/handler/StarterHmilyTacTransactionHandler.java
@@ -68,7 +68,7 @@ public class StarterHmilyTacTransactionHandler implements HmilyTransactionHandle
         MetricsReporter.counterIncrement(LabelNames.TRANSACTION_TOTAL, new String[]{TransTypeEnum.TAC.name()});
         LocalDateTime starterTime = LocalDateTime.now();
         try {
-            tm.begin();
+            tm.begin(point);
             try {
                 //execute try
                 returnValue = point.proceed();


### PR DESCRIPTION

1. 在 `HmilyTac` 注解增加 `isolationLevel `属性, 用来确定 tac 模式下的隔离级别, 默认为 read uncommitted；
2. 开启全局事务，创建 `HmilyTransactionContext` 对象时，保存对应的隔离级别；
3. 执行 `select SQL` 时，根据 `HmilyTransactionContext` 对象的 `isolationLevel` 判断是否需要 `checkLocks`；
4. 修改 `tac demo` 中对应的读已提交测试案例。
